### PR TITLE
Record constructors

### DIFF
--- a/src/alpha.sml
+++ b/src/alpha.sml
@@ -159,6 +159,11 @@ structure Alpha :> ALPHA = struct
         The (ty, alphaRename s exp)
       | alphaRename s (OAST.Construct (ty, label, exp)) =
         Construct (ty, label, Option.map (alphaRename s) exp)
+      | alphaRename s (OAST.MakeRecord (ty, slots)) =
+        MakeRecord (ty,
+                    map (fn (n, exp) =>
+                            (n, alphaRename s exp))
+                        slots)
       | alphaRename s (OAST.Case (exp, cases)) =
         let val exp' = alphaRename s exp
         in

--- a/src/ast.sml
+++ b/src/ast.sml
@@ -108,6 +108,11 @@ structure AST :> AST = struct
         The (ty, transform exp)
       | transform (Alpha.Construct (ty, label, exp)) =
         Construct (ty, label, Option.map transform exp)
+      | transform (Alpha.MakeRecord (ty, slots)) =
+        MakeRecord (ty,
+                    map (fn (name, exp) =>
+                            (name, transform exp))
+                        slots)
       | transform (Alpha.Case (exp, cases)) =
         let fun transformCase (Alpha.VariantCase (name, body)) =
                 VariantCase (transformCaseName name, transform body)

--- a/src/c-backend.sml
+++ b/src/c-backend.sml
@@ -199,6 +199,11 @@ structure CBackend :> C_BACKEND = struct
         C.StructInitializer (transformType ty,
                              [(disjTagFieldName, C.IntConstant (Int.toString id)),
                               (disjDataFieldName, C.IntConstant "0")])
+      | transform (LIR.MakeRecord (ty, slots)) _ =
+        C.StructInitializer (transformType ty,
+                             map (fn (name, oper) =>
+                                     (escapeSymbol name, transformOperand oper))
+                                 slots)
       | transform (LIR.UnsafeExtractCase (oper, id)) ty =
         C.StructAccess (C.StructAccess (transformOperand oper, disjDataFieldName),
                         tupleIdxName id)

--- a/src/c-backend.sml
+++ b/src/c-backend.sml
@@ -338,7 +338,7 @@ structure CBackend :> C_BACKEND = struct
         let val name = disjName name id
             and slots = map (fn (name, ty) =>
                                 (transformType ty, escapeSymbol name))
-                            slots
+                            (Map.toList slots)
         in
             C.TypeDef (name, C.Struct slots)
         end

--- a/src/compiler.sml
+++ b/src/compiler.sml
@@ -330,7 +330,7 @@ structure Compiler : COMPILER = struct
       | defineType c (DAST.Defrecord (name, typarams, _, slots)) =
         let val tenv = compilerTenv c
         in
-            compilerFromTenv c (Type.addDefinition tenv (name, typarams, Type.RecordDef slots))
+            compilerFromTenv c (Type.addDefinition tenv (name, typarams, Type.RecordDef (Map.fromList slots)))
         end
       | defineType c _ =
         c

--- a/src/dast.sig
+++ b/src/dast.sig
@@ -31,7 +31,7 @@ signature DAST = sig
                      | Definstance of name * instance_arg * docstring * method_def list
                      | Deftype of name * Type.typarams * docstring * ty
                      | Defdatatype of name * Type.typarams * docstring * Type.variant list
-                     | Defrecord of name * Type.typarams * docstring * Type.slot list
+                     | Defrecord of name * Type.typarams * docstring * (name * ty) list
                      | Deftemplate of Macro.template
                      | DefineSymbolMacro of name * RCST.rcst * docstring
                      | Defmodule of Symbol.module_name * Module.defmodule_clause list

--- a/src/dast.sml
+++ b/src/dast.sml
@@ -31,7 +31,7 @@ structure DAST :> DAST = struct
                      | Definstance of name * instance_arg * docstring * method_def list
                      | Deftype of name * Type.typarams * docstring * ty
                      | Defdatatype of name * Type.typarams * docstring * Type.variant list
-                     | Defrecord of name * Type.typarams * docstring * Type.slot list
+                     | Defrecord of name * Type.typarams * docstring * (name * ty) list
                      | Deftemplate of Macro.template
                      | DefineSymbolMacro of name * RCST.rcst * docstring
                      | Defmodule of Symbol.module_name * Module.defmodule_clause list

--- a/src/dast.sml
+++ b/src/dast.sml
@@ -131,8 +131,8 @@ structure DAST :> DAST = struct
         let val params' = OrderedSet.fromList (map (fn name => Type.TypeParam name) params)
         in
             let fun mapSlot (AST.Slot (name, typespec, _)) =
-                    Type.Slot (name,
-                               Type.resolve tenv (OrderedSet.toUnordered params') typespec)
+                    (name,
+                     Type.resolve tenv (OrderedSet.toUnordered params') typespec)
             in
                 Defrecord (name,
                            params',

--- a/src/hir-pass.sml
+++ b/src/hir-pass.sml
@@ -214,12 +214,12 @@ structure HirPass :> HIR_PASS = struct
                          id,
                          map transformType tys)
       | transformTop _ (M.DefrecordMono (name, id, slots)) =
-        let fun mapSlot (MonoType.Slot (name, ty)) =
+        let fun mapSlot (name, ty) =
                 (name, transformType ty)
         in
             DefrecordMono (name,
                            id,
-                           map mapSlot slots)
+                           Map.fromList (map mapSlot (Map.toList slots)))
         end
       | transformTop _ (M.Defcfun (_, rawname, params, arity, rt)) =
         Defcfun (rawname,

--- a/src/hir-pass.sml
+++ b/src/hir-pass.sml
@@ -137,6 +137,11 @@ structure HirPass :> HIR_PASS = struct
         Construct (transformType ty,
                    caseNameIdx e ty name,
                    Option.map (transform e) value)
+      | transform e (M.MakeRecord (ty, slots)) =
+        MakeRecord (transformType ty,
+                    map (fn (name, exp) =>
+                            (name, transform e exp))
+                        slots)
       | transform e (M.Case (exp, cases, ty)) =
         let val expTy = MTAST.typeOf exp
         in

--- a/src/hir.sig
+++ b/src/hir.sig
@@ -52,6 +52,7 @@ signature HIR = sig
                  | Store of ast * ast
                  | AddressOffset of ast * ast
                  | Construct of ty * int * ast option
+                 | MakeRecord of ty * (name * ast) list
                  | Case of ast * variant_case list * ty
                  | UnsafeExtractCase of ast * int * ty
                  | ForeignFuncall of string * ast list * ty

--- a/src/hir.sig
+++ b/src/hir.sig
@@ -71,7 +71,7 @@ signature HIR = sig
     datatype top_ast = Defun of name * param list * ty * ast
                      | DefunMonomorph of name * param list * ty * ast * int
                      | DefdatatypeMono of name * int * ty list
-                     | DefrecordMono of name * int * (name * ty) list
+                     | DefrecordMono of name * int * (name, ty) Map.map
                      | Defcfun of string * ty list * Function.foreign_arity * ty
                      | ToplevelProgn of top_ast list
          and param = Param of Symbol.variable * ty

--- a/src/hir.sml
+++ b/src/hir.sml
@@ -136,7 +136,7 @@ structure HIR :> HIR = struct
     datatype top_ast = Defun of name * param list * ty * ast
                      | DefunMonomorph of name * param list * ty * ast * int
                      | DefdatatypeMono of name * int * ty list
-                     | DefrecordMono of name * int * (name * ty) list
+                     | DefrecordMono of name * int * (name, ty) Map.map
                      | Defcfun of string * ty list * Function.foreign_arity * ty
                      | ToplevelProgn of top_ast list
          and param = Param of Symbol.variable * ty

--- a/src/hir.sml
+++ b/src/hir.sml
@@ -111,6 +111,8 @@ structure HIR :> HIR = struct
         typeOf addr
       | typeOf (Construct (t, _, _)) =
         t
+      | typeOf (MakeRecord (t, _)) =
+        t
       | typeOf (Case (_, _, t)) =
         t
       | typeOf (UnsafeExtractCase (_, _, t)) =

--- a/src/hir.sml
+++ b/src/hir.sml
@@ -52,6 +52,7 @@ structure HIR :> HIR = struct
                  | Store of ast * ast
                  | AddressOffset of ast * ast
                  | Construct of ty * int * ast option
+                 | MakeRecord of ty * (name * ast) list
                  | Case of ast * variant_case list * ty
                  | UnsafeExtractCase of ast * int * ty
                  | ForeignFuncall of string * ast list * ty

--- a/src/lir-pass.sml
+++ b/src/lir-pass.sml
@@ -393,10 +393,10 @@ structure LirPass :> LIR_PASS = struct
         in
             let val (slots', tt) = Util.foldThread (fn (slot, tt) =>
                                                        mapSlot slot tt)
-                                                   slots
+                                                   (Map.toList slots)
                                                    tt
             in
-                (LIR.DefrecordMono (name, id, slots'), tt)
+                (LIR.DefrecordMono (name, id, Map.fromList slots'), tt)
             end
         end
       | transformTop' tt (MIR.Defcfun (rawname, tys, arity, rt)) =

--- a/src/lir-pass.sml
+++ b/src/lir-pass.sml
@@ -197,6 +197,20 @@ structure LirPass :> LIR_PASS = struct
         in
             (L.Construct (ty, id, NONE), tt)
         end
+      | transformOperation tt (MIR.MakeRecord (ty, slots)) =
+        let val (ty, tt) = transformType tt ty
+        in
+            let val (slots, tt) = Util.foldThread (fn ((name, oper), tt) =>
+                                                      let val (oper, tt) = transformOperand tt oper
+                                                      in
+                                                          ((name, oper), tt)
+                                                      end)
+                                                  slots
+                                                  tt
+            in
+                (L.MakeRecord (ty, slots), tt)
+            end
+        end
       | transformOperation tt (MIR.UnsafeExtractCase (oper, id)) =
         let val (oper, tt) = transformOperand tt oper
         in

--- a/src/lir.sig
+++ b/src/lir.sig
@@ -48,6 +48,7 @@ signature LIR = sig
                        | Load of operand
                        | AddressOffset of operand * operand
                        | Construct of ty * int * operand option
+                       | MakeRecord of ty * (name * operand) list
                        | UnsafeExtractCase of operand * int
                        | ForeignFuncall of string * operand list
                        | NullPointer of ty

--- a/src/lir.sig
+++ b/src/lir.sig
@@ -77,7 +77,7 @@ signature LIR = sig
     datatype top_ast = Defun of name * param list * ty * instruction list * operand
                      | DefunMonomorph of name * param list * ty * instruction list * operand * int
                      | DefdatatypeMono of name * int * ty list
-                     | DefrecordMono of name * int * (name * ty) list
+                     | DefrecordMono of name * int * (name, ty) Map.map
                      | Deftuple of int * ty list
                      | Defcfun of string * ty list * Function.foreign_arity * ty
                      | ToplevelProgn of top_ast list

--- a/src/lir.sml
+++ b/src/lir.sml
@@ -77,7 +77,7 @@ structure LIR :> LIR = struct
     datatype top_ast = Defun of name * param list * ty * instruction list * operand
                      | DefunMonomorph of name * param list * ty * instruction list * operand * int
                      | DefdatatypeMono of name * int * ty list
-                     | DefrecordMono of name * int * (name * ty) list
+                     | DefrecordMono of name * int * (name, ty) Map.map
                      | Deftuple of int * ty list
                      | Defcfun of string * ty list * Function.foreign_arity * ty
                      | ToplevelProgn of top_ast list

--- a/src/lir.sml
+++ b/src/lir.sml
@@ -48,6 +48,7 @@ structure LIR :> LIR = struct
                        | Load of operand
                        | AddressOffset of operand * operand
                        | Construct of ty * int * operand option
+                       | MakeRecord of ty * (name * operand) list
                        | UnsafeExtractCase of operand * int
                        | ForeignFuncall of string * operand list
                        | NullPointer of ty

--- a/src/mir-pass.sml
+++ b/src/mir-pass.sml
@@ -376,9 +376,13 @@ structure MirPass :> MIR_PASS = struct
                              id,
                              map transformType tys)
       | transformTop (HIR.DefrecordMono (name, id, slots)) =
-        MIR.DefrecordMono (name,
-                           id,
-                           map (fn (n, t) => (n, transformType t)) slots)
+        let val slots = map (fn (n, t) => (n, transformType t))
+                            (Map.toList slots)
+        in
+            MIR.DefrecordMono (name,
+                               id,
+                               Map.fromList slots)
+        end
       | transformTop (HIR.Defcfun (rawname, tys, arity, rt)) =
         Defcfun (rawname,
                  map transformType tys,

--- a/src/mir-pass.sml
+++ b/src/mir-pass.sml
@@ -212,6 +212,25 @@ structure MirPass :> MIR_PASS = struct
             ([Assignment (result, Construct (transformType ty, caseId, NONE), ty')],
              RegisterOp result)
         end
+      | transform (HIR.MakeRecord (ty, slots)) =
+        let val slots' = map (fn (name, exp) =>
+                                 (name, transform exp))
+                             slots
+            and result = freshRegister ()
+            and ty = transformType ty
+        in
+            let val expBlocks = map (fn (_, (is, _)) => is) slots'
+                and cslots = map (fn (name, (_, oper)) =>
+                                     (name, oper))
+                                 slots'
+            in
+                let val nodes = (List.concat expBlocks)
+                                @ [Assignment (result, MakeRecord (ty, cslots), ty)]
+                in
+                    (nodes, RegisterOp result)
+                end
+            end
+        end
       | transform (HIR.Case (exp, cases, ty)) =
         transformCases exp cases ty
       | transform (HIR.UnsafeExtractCase (exp, caseId, ty)) =

--- a/src/mir.sig
+++ b/src/mir.sig
@@ -80,7 +80,7 @@ signature MIR = sig
     datatype top_ast = Defun of name * param list * ty * instruction list * operand
                      | DefunMonomorph of name * param list * ty * instruction list * operand * int
                      | DefdatatypeMono of name * int * ty list
-                     | DefrecordMono of name * int * (name * ty) list
+                     | DefrecordMono of name * int * (name, ty) Map.map
                      | Defcfun of string * ty list * Function.foreign_arity * ty
                      | ToplevelProgn of top_ast list
          and param = Param of Symbol.variable * ty

--- a/src/mir.sig
+++ b/src/mir.sig
@@ -51,7 +51,7 @@ signature MIR = sig
                        | Load of operand
                        | AddressOffset of operand * operand
                        | Construct of ty * int * operand option
-                       | MakeRecord of ty * (name * ast) list
+                       | MakeRecord of ty * (name * operand) list
                        | UnsafeExtractCase of operand * int
                        | ForeignFuncall of string * operand list
                        | NullPointer of ty

--- a/src/mir.sig
+++ b/src/mir.sig
@@ -51,6 +51,7 @@ signature MIR = sig
                        | Load of operand
                        | AddressOffset of operand * operand
                        | Construct of ty * int * operand option
+                       | MakeRecord of ty * (name * ast) list
                        | UnsafeExtractCase of operand * int
                        | ForeignFuncall of string * operand list
                        | NullPointer of ty

--- a/src/mir.sml
+++ b/src/mir.sml
@@ -51,7 +51,7 @@ structure MIR :> MIR = struct
                        | Load of operand
                        | AddressOffset of operand * operand
                        | Construct of ty * int * operand option
-                       | MakeRecord of ty * (name * ast) list
+                       | MakeRecord of ty * (name * operand) list
                        | UnsafeExtractCase of operand * int
                        | ForeignFuncall of string * operand list
                        | NullPointer of ty

--- a/src/mir.sml
+++ b/src/mir.sml
@@ -80,7 +80,7 @@ structure MIR :> MIR = struct
     datatype top_ast = Defun of name * param list * ty * instruction list * operand
                      | DefunMonomorph of name * param list * ty * instruction list * operand * int
                      | DefdatatypeMono of name * int * ty list
-                     | DefrecordMono of name * int * (name * ty) list
+                     | DefrecordMono of name * int * (name, ty) Map.map
                      | Defcfun of string * ty list * Function.foreign_arity * ty
                      | ToplevelProgn of top_ast list
          and param = Param of Symbol.variable * ty

--- a/src/mir.sml
+++ b/src/mir.sml
@@ -51,6 +51,7 @@ structure MIR :> MIR = struct
                        | Load of operand
                        | AddressOffset of operand * operand
                        | Construct of ty * int * operand option
+                       | MakeRecord of ty * (name * ast) list
                        | UnsafeExtractCase of operand * int
                        | ForeignFuncall of string * operand list
                        | NullPointer of ty

--- a/src/module.sml
+++ b/src/module.sml
@@ -95,6 +95,7 @@ structure Module : MODULE = struct
                 "./",
                 "tuple",
                 "proj",
+                "record",
                 "static-array-length",
                 "static-array-pointer",
                 "null-pointer",

--- a/src/mono-type.sig
+++ b/src/mono-type.sig
@@ -55,5 +55,5 @@ signature MONO_TYPE = sig
 
     val monomorphize : type_monomorphs -> replacements -> Type.ty -> (ty * type_monomorphs)
     val monomorphizeVariants : type_monomorphs -> replacements -> Type.variant list -> (variant list * type_monomorphs)
-    val monomorphizeSlots : type_monomorphs -> replacements -> Type.slot list -> (slot list * type_monomorphs)
+    val monomorphizeSlots : type_monomorphs -> replacements -> (name, ty) Map.map -> (slot list * type_monomorphs)
 end

--- a/src/mono-type.sig
+++ b/src/mono-type.sig
@@ -52,8 +52,9 @@ signature MONO_TYPE = sig
     val newMonomorphs : type_monomorphs -> type_monomorphs -> (name * ty list * ty * int) list
 
     type replacements = (name, ty) Map.map
+    type slots = (name, ty) Map.map
 
     val monomorphize : type_monomorphs -> replacements -> Type.ty -> (ty * type_monomorphs)
     val monomorphizeVariants : type_monomorphs -> replacements -> Type.variant list -> (variant list * type_monomorphs)
-    val monomorphizeSlots : type_monomorphs -> replacements -> (name, ty) Map.map -> (slot list * type_monomorphs)
+    val monomorphizeSlots : type_monomorphs -> replacements -> slots -> (slots * type_monomorphs)
 end

--- a/src/mono-type.sig
+++ b/src/mono-type.sig
@@ -36,8 +36,6 @@ signature MONO_TYPE = sig
 
     datatype variant = Variant of name * ty option
 
-    datatype slot = Slot of name * ty
-
     val disjName : ty -> name
 
     (* Type monomorphization *)

--- a/src/mono-type.sig
+++ b/src/mono-type.sig
@@ -56,5 +56,5 @@ signature MONO_TYPE = sig
 
     val monomorphize : type_monomorphs -> replacements -> Type.ty -> (ty * type_monomorphs)
     val monomorphizeVariants : type_monomorphs -> replacements -> Type.variant list -> (variant list * type_monomorphs)
-    val monomorphizeSlots : type_monomorphs -> replacements -> slots -> (slots * type_monomorphs)
+    val monomorphizeSlots : type_monomorphs -> replacements -> (name, Type.ty) Map.map -> (slots * type_monomorphs)
 end

--- a/src/mono-type.sml
+++ b/src/mono-type.sml
@@ -84,6 +84,8 @@ structure MonoType :> MONO_TYPE = struct
 
     type replacements = (name, ty) Map.map
 
+    type slots = (name, ty) Map.map
+
     fun monomorphize tm _ Type.Unit =
         (Unit, tm)
       | monomorphize tm _ Type.Bool =

--- a/src/mono-type.sml
+++ b/src/mono-type.sml
@@ -198,14 +198,17 @@ structure MonoType :> MONO_TYPE = struct
     (* Monomorphize slots *)
 
     and monomorphizeSlots tm rs slots =
-        Util.foldThread (fn (slot, tm) =>
-                            monomorphizeSlot tm rs slot)
-                        slots
-                        tm
+        let val (slots', tm) = Util.foldThread (fn (slot, tm) =>
+                                                   monomorphizeSlot tm rs slot)
+                                               (Map.toList slots)
+                                               tm
+        in
+            (Map.fromList slots', tm)
+        end
 
-    and monomorphizeSlot tm rs (Type.Slot (name, ty)) =
+    and monomorphizeSlot tm rs (name, ty) =
         let val (ty', tm') = monomorphize tm rs ty
         in
-            (Slot (name, ty'), tm')
+            ((name, ty'), tm')
         end
 end

--- a/src/mono-type.sml
+++ b/src/mono-type.sml
@@ -36,8 +36,6 @@ structure MonoType :> MONO_TYPE = struct
 
     datatype variant = Variant of name * ty option
 
-    datatype slot = Slot of name * ty
-
     fun disjName (Disjunction (name, _)) =
         name
       | disjName _ =

--- a/src/mtast.sig
+++ b/src/mtast.sig
@@ -67,7 +67,7 @@ signature MTAST = sig
     datatype top_ast = Defun of name * param list * ty * ast
                      | DefunMonomorph of name * param list * ty * ast * int
                      | DefdatatypeMono of name * int * ty list
-                     | DefrecordMono of name * int * MonoType.slot list
+                     | DefrecordMono of name * int * MonoType.slots
                      | Defcfun of name * string * param list * Function.foreign_arity * ty
                      | ToplevelProgn of top_ast list
          and param = Param of Symbol.variable * ty

--- a/src/mtast.sml
+++ b/src/mtast.sml
@@ -372,6 +372,20 @@ structure MTAST :> MTAST = struct
                      in
                          (Construct (ty', name, NONE), ctx)
                      end)
+      | monomorphize ctx rs (TAST.MakeRecord (ty, slots)) =
+        let val (ty, ctx) = monoType ctx rs ty
+        in
+            let val (slots, ctx) = Util.foldThread (fn ((name, ty), ctx) =>
+                                                       let val (ty, ctx) = monoType ctx rs ty
+                                                       in
+                                                           ((name, ty), ctx)
+                                                       end)
+                                                   slots
+                                                   ctx
+            in
+                (MakeRecord (ty, slots), ctx)
+            end
+        end
       | monomorphize ctx rs (TAST.Case (exp, cases, ty)) =
         let val (exp', ctx) = monomorphize ctx rs exp
         in

--- a/src/mtast.sml
+++ b/src/mtast.sml
@@ -650,10 +650,10 @@ structure MTAST :> MTAST = struct
             in
                 let val (slots', ctx) = Util.foldThread (fn (var, ctx) =>
                                                             mapSlot ctx var)
-                                                        slots
+                                                        (Map.toList slots)
                                                         ctx
                 in
-                    DefrecordMono (name, id, slots')
+                    DefrecordMono (name, id, Map.fromList slots')
                 end
             end
         end

--- a/src/mtast.sml
+++ b/src/mtast.sml
@@ -642,10 +642,10 @@ structure MTAST :> MTAST = struct
         (* Monomorphize the slots *)
         let val rs = makeReplacements typarams tyargs
         in
-            let fun mapSlot ctx (Type.Slot (name, ty)) =
+            let fun mapSlot ctx (name, ty) =
                     let val (ty, ctx) = monoType ctx rs ty
                     in
-                        (MonoType.Slot (name, ty), ctx)
+                        ((name, ty), ctx)
                     end
             in
                 let val (slots', ctx) = Util.foldThread (fn (var, ctx) =>

--- a/src/mtast.sml
+++ b/src/mtast.sml
@@ -46,6 +46,7 @@ structure MTAST :> MTAST = struct
                  | AddressOffset of ast * ast
                  | The of ty * ast
                  | Construct of ty * name * ast option
+                 | MakeRecord of ty * (name * ast) list
                  | Case of ast * variant_case list * ty
                  | ForeignFuncall of string * ast list * ty
                  | NullPointer of ty

--- a/src/mtast.sml
+++ b/src/mtast.sml
@@ -121,6 +121,8 @@ structure MTAST :> MTAST = struct
             t
           | typeOf (Construct (t, _, _)) =
             t
+          | typeOf (MakeRecord (t, _)) =
+            t
           | typeOf (Case (_, _, t)) =
             t
           | typeOf (SizeOf _) =

--- a/src/mtast.sml
+++ b/src/mtast.sml
@@ -375,10 +375,10 @@ structure MTAST :> MTAST = struct
       | monomorphize ctx rs (TAST.MakeRecord (ty, slots)) =
         let val (ty, ctx) = monoType ctx rs ty
         in
-            let val (slots, ctx) = Util.foldThread (fn ((name, ty), ctx) =>
-                                                       let val (ty, ctx) = monoType ctx rs ty
+            let val (slots, ctx) = Util.foldThread (fn ((name, exp), ctx) =>
+                                                       let val (exp, ctx) = monomorphize ctx rs exp
                                                        in
-                                                           ((name, ty), ctx)
+                                                           ((name, exp), ctx)
                                                        end)
                                                    slots
                                                    ctx

--- a/src/mtast.sml
+++ b/src/mtast.sml
@@ -148,7 +148,7 @@ structure MTAST :> MTAST = struct
     datatype top_ast = Defun of name * param list * ty * ast
                      | DefunMonomorph of name * param list * ty * ast * int
                      | DefdatatypeMono of name * int * ty list
-                     | DefrecordMono of name * int * MonoType.slot list
+                     | DefrecordMono of name * int * MonoType.slots
                      | Defcfun of name * string * param list * Function.foreign_arity * ty
                      | ToplevelProgn of top_ast list
          and param = Param of Symbol.variable * ty

--- a/src/oast.sml
+++ b/src/oast.sml
@@ -119,6 +119,8 @@ structure OAST :> OAST = struct
             transformLet args
         else if f = au "bind" then
             transformBind args
+        else if f = au "record" then
+            transformRecord args
         else if f = au "malloc" then
             transformMalloc args
         else if f = au "the" then

--- a/src/oast.sml
+++ b/src/oast.sml
@@ -170,6 +170,16 @@ structure OAST :> OAST = struct
       | transformBind _ =
         raise Fail "Invalid `bind` form"
 
+    and transformRecord (ty::slots) =
+        let fun transformSlot _ =
+                raise Fail "Not done yet"
+        in
+            MakeRecord (Type.parseTypespec ty,
+                        map transformSlot slots)
+        end
+      | transformRecord _ =
+        raise Fail "Invalid `record` form"
+
     and transformMalloc [ty, len] =
         Malloc (Type.parseTypespec ty, transform len)
       | transformMalloc _ =

--- a/src/oast.sml
+++ b/src/oast.sml
@@ -171,8 +171,10 @@ structure OAST :> OAST = struct
         raise Fail "Invalid `bind` form"
 
     and transformRecord (ty::slots) =
-        let fun transformSlot _ =
-                raise Fail "Not done yet"
+        let fun transformSlot (RCST.List [RCST.Symbol name, value]) =
+                (name, transform value)
+              | transformSlot _ =
+                raise Fail "Invalid `record` form slot value"
         in
             MakeRecord (Type.parseTypespec ty,
                         map transformSlot slots)

--- a/src/set.sml
+++ b/src/set.sml
@@ -37,7 +37,8 @@ structure Set :> SET = struct
     fun isIn set elem = Util.member elem set
 
     fun eq a b =
-        List.all (fn aelem => isIn b aelem) a
+        (List.all (fn aelem => isIn b aelem) a)
+        andalso (length a = length b)
 
     fun union a b = addList (addList empty a) b
 

--- a/src/tast.sig
+++ b/src/tast.sig
@@ -70,7 +70,7 @@ signature TAST = sig
                      | Definstance of name * instance_arg * docstring * method_def list
                      | Deftype of name * Type.typarams * docstring * ty
                      | Defdatatype of name * Type.typarams * docstring * Type.variant list
-                     | Defrecord of name * Type.typarams * docstring * Type.slot list
+                     | Defrecord of name * Type.typarams * docstring * (name * ty) list
                      | Deftemplate of Macro.template
                      | DefineSymbolMacro of name * RCST.rcst * docstring
                      | Defmodule of Symbol.module_name * Module.defmodule_clause list

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -456,7 +456,7 @@ structure TAST :> TAST = struct
                   slot has the same type.
 
              *)
-            let fun augment' name tyargs slots =
+            let fun augment' name typarams tyargs slots =
                     let val slotNames = Map.keys slots
                         and consNames = Set.fromList (map (fn (n, _) => n) cslots)
                     in
@@ -486,7 +486,7 @@ structure TAST :> TAST = struct
                                                                           (SOME (typarams, _)) => typarams
                                                                         | _ => raise Fail "Internal error"
                                                    in
-                                                       augment' name tyargs slots
+                                                       augment' name typarams tyargs slots
                                                    end
                       | _ => raise Fail ("record: not a record: " ^ (Type.toString ty))
                 end

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -461,18 +461,23 @@ structure TAST :> TAST = struct
                         and consNames = Set.fromList (map (fn (n, _) => n) cslots)
                     in
                         if Set.eq slotNames consNames then
-                            let val slots' = map (fn (name, exp) =>
-                                                     let val exp' = augment exp c
-                                                     in
-                                                         let val ty = Option.valOf (Map.get slots name)
-                                                         in
-                                                             raise Fail "Not done yet"
-                                                         end
-                                                     end)
-                                                 cslots
+                            let val slots = map (fn (name, exp) =>
+                                                    let val exp' = augment exp c
+                                                    in
+                                                        let val ty = Option.valOf (Map.get slots name)
+                                                        in
+                                                            raise Fail "Not done yet"
+                                                        end
+                                                    end)
+                                                cslots
                             in
-                                MakeRecord (Type.Record (name, tyargs),
-                                            slots')
+                                let val ty = Type.Record (name, tyargs)
+                                in
+                                    let val ty = replaceVars (replacements typarams tyargs) ty
+                                    in
+                                        MakeRecord (ty, slots)
+                                    end
+                                end
                             end
                         else
                             raise Fail "Set of slot names and set of constructor slot names differs"

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -466,7 +466,10 @@ structure TAST :> TAST = struct
                                                     in
                                                         let val ty = Option.valOf (Map.get slots name)
                                                         in
-                                                            raise Fail "Not done yet"
+                                                            if typeOf exp' = ty then
+                                                                (name, exp')
+                                                            else
+                                                                raise Fail "Record constructor type mismatch"
                                                         end
                                                     end)
                                                 cslots

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -145,6 +145,8 @@ structure TAST :> TAST = struct
             t
           | typeOf (Construct (t, _, _)) =
             t
+          | typeOf (MakeRecord (t, _)) =
+            t
           | typeOf (Case (_, _, t)) =
             t
           | typeOf (SizeOf _) =

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -443,8 +443,9 @@ structure TAST :> TAST = struct
                      end
                   | _ => raise Fail "construct: not a datatype"
             end
-          | augment (AST.MakeRecord (typespec, slots)) c =
-            (* Steps:
+          | augment (AST.MakeRecord (typespec, cslots)) c =
+            (*
+               Steps:
 
                1. Resolve the type specifier, and ensure it is a record.
 
@@ -453,9 +454,17 @@ structure TAST :> TAST = struct
 
                3. For each slot value in the constructor, ensure the associated
                   slot has the same type.
+
              *)
             let fun augment' name tyargs slots =
-                    raise Fail "Not done"
+                    let val slotNames = Set.fromList (map (fn (n, _) => n) slots)
+                        and consNames = Set.fromList (map (fn (n, _) => n) cslots)
+                    in
+                        if Set.eq slotNames consNames then
+                            raise Fail "Not done yet"
+                        else
+                            raise Fail "Set of slot names and set of constructor slot names differs"
+                    end
             in
                 let val ty = resolve (ctxTenv c) (ctxTyParams c) typespec
                 in

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -461,7 +461,19 @@ structure TAST :> TAST = struct
                         and consNames = Set.fromList (map (fn (n, _) => n) cslots)
                     in
                         if Set.eq slotNames consNames then
-                            raise Fail "Not done yet"
+                            let val slots' = map (fn (name, exp) =>
+                                                     let val exp' = augment exp c
+                                                     in
+                                                         let val ty = Option.valOf (Map.get slots name)
+                                                         in
+                                                             raise Fail "Not done yet"
+                                                         end
+                                                     end)
+                                                 cslots
+                            in
+                                MakeRecord (Type.Record (name, tyargs),
+                                            slots')
+                            end
                         else
                             raise Fail "Set of slot names and set of constructor slot names differs"
                     end

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -469,7 +469,10 @@ structure TAST :> TAST = struct
                                                             if typeOf exp' = ty then
                                                                 (name, exp')
                                                             else
-                                                                raise Fail "Record constructor type mismatch"
+                                                                raise Fail ("Record constructor type mismatch: "
+                                                                            ^ (Type.toString (typeOf exp'))
+                                                                            ^ ", "
+                                                                            ^ (Type.toString ty))
                                                         end
                                                     end)
                                                 cslots

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -454,7 +454,16 @@ structure TAST :> TAST = struct
                3. For each slot value in the constructor, ensure the associated
                   slot has the same type.
              *)
-
+            let fun augment' name tyargs =
+                    raise Fail "Not done yet"
+            in
+                let val ty = resolve (ctxTenv c) (ctxTyParams c) typespec
+                in
+                    case ty of
+                        (Record (name, tyargs)) => augment' name tyargs
+                      | _ => raise Fail ("record: not a record: " ^ (Type.toString ty))
+                end
+            end
           | augment (AST.Case (exp, cases)) c =
             (*
                Things we have to verify:

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -454,13 +454,16 @@ structure TAST :> TAST = struct
                3. For each slot value in the constructor, ensure the associated
                   slot has the same type.
              *)
-            let fun augment' name tyargs =
-                    raise Fail "Not done yet"
+            let fun augment' name tyargs slots =
+                    raise Fail "Not done"
             in
                 let val ty = resolve (ctxTenv c) (ctxTyParams c) typespec
                 in
                     case ty of
-                        (Record (name, tyargs)) => augment' name tyargs
+                        (Record (name, tyargs)) => let val slots = Type.getRecordSlots (ctxTenv c) name
+                                                   in
+                                                       augment' name tyargs slots
+                                                   end
                       | _ => raise Fail ("record: not a record: " ^ (Type.toString ty))
                 end
             end

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -457,7 +457,7 @@ structure TAST :> TAST = struct
 
              *)
             let fun augment' name tyargs slots =
-                    let val slotNames = Set.fromList (map (fn (Type.Slot (n, _)) => n) slots)
+                    let val slotNames = Map.keys slots
                         and consNames = Set.fromList (map (fn (n, _) => n) cslots)
                     in
                         if Set.eq slotNames consNames then

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -70,7 +70,7 @@ structure TAST :> TAST = struct
                      | Definstance of name * instance_arg * docstring * method_def list
                      | Deftype of name * Type.typarams * docstring * ty
                      | Defdatatype of name * Type.typarams * docstring * Type.variant list
-                     | Defrecord of name * Type.typarams * docstring * Type.slot list
+                     | Defrecord of name * Type.typarams * docstring * (name * ty) list
                      | Deftemplate of Macro.template
                      | DefineSymbolMacro of name * RCST.rcst * docstring
                      | Defmodule of Symbol.module_name * Module.defmodule_clause list

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -443,6 +443,18 @@ structure TAST :> TAST = struct
                      end
                   | _ => raise Fail "construct: not a datatype"
             end
+          | augment (AST.MakeRecord (typespec, slots)) c =
+            (* Steps:
+
+               1. Resolve the type specifier, and ensure it is a record.
+
+               2. Ensure the set of slot names in the type definition is the
+                  same as the set of slot names in the constructor.
+
+               3. For each slot value in the constructor, ensure the associated
+                  slot has the same type.
+             *)
+
           | augment (AST.Case (exp, cases)) c =
             (*
                Things we have to verify:

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -482,6 +482,9 @@ structure TAST :> TAST = struct
                 in
                     case ty of
                         (Record (name, tyargs)) => let val slots = Type.getRecordSlots (ctxTenv c) name
+                                                       and typarams = case Type.getDeclaration (ctxTenv c) name of
+                                                                          (SOME (typarams, _)) => typarams
+                                                                        | _ => raise Fail "Internal error"
                                                    in
                                                        augment' name tyargs slots
                                                    end

--- a/src/tast.sml
+++ b/src/tast.sml
@@ -457,7 +457,7 @@ structure TAST :> TAST = struct
 
              *)
             let fun augment' name tyargs slots =
-                    let val slotNames = Set.fromList (map (fn (n, _) => n) slots)
+                    let val slotNames = Set.fromList (map (fn (Type.Slot (n, _)) => n) slots)
                         and consNames = Set.fromList (map (fn (n, _) => n) cslots)
                     in
                         if Set.eq slotNames consNames then

--- a/src/type.sig
+++ b/src/type.sig
@@ -66,9 +66,8 @@ signature TYPE = sig
 
     datatype typedef = AliasDef of ty
                      | DisjunctionDef of variant list
-                     | RecordDef of slot list
+                     | RecordDef of (name, ty) Map.map
          and variant = Variant of name * ty option
-         and slot = Slot of name * ty
 
     val defaultTenv : tenv
 
@@ -105,5 +104,5 @@ signature TYPE = sig
     val getVariantByName : variant list -> name -> variant option
     val posInVariants : variant list -> name -> int option
 
-    val getRecordSlots : tenv -> name -> slot list
+    val getRecordSlots : tenv -> name -> (name, ty) Map.map
 end

--- a/src/type.sml
+++ b/src/type.sml
@@ -137,9 +137,8 @@ structure Type :> TYPE = struct
 
     datatype typedef = AliasDef of ty
                      | DisjunctionDef of variant list
-                     | RecordDef of slot list
+                     | RecordDef of (name, ty) Map.map
          and variant = Variant of name * ty option
-         and slot = Slot of name * ty
 
     type defmap = (name, (typarams * typedef)) Map.map
 

--- a/test/valid/defrecord.au
+++ b/test/valid/defrecord.au
@@ -5,4 +5,5 @@
   (b f32))
 
 (defun main () i32
-  0)
+  (let ((p (record pair (a 10) (b 3.14))))
+    0))

--- a/test/valid/defrecord.au
+++ b/test/valid/defrecord.au
@@ -2,7 +2,7 @@
 
 (defrecord pair ()
   (a i32)
-  (b f32))
+  (b f64))
 
 (defun main () i32
   (let ((p (record pair (a 10) (b 3.14))))


### PR DESCRIPTION
This PR implements the `record` special form.

Additionally, the definition of the `Record` case in `Type.ty` has changed to use a map of slot names to types.