### PR TITLE
Add support for a Root_Capability type which is the sole parameter to entrypoint functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The `--entrypoint` option must be the name of a module, followed by a colon,
 followed by the name of a public function with the following signature:
 
 ```
-function Main(): Unit;
+function Main(root: Root_Capability): Root_Capability;
 ```
 
 Finally, the `--output` option is just the path to dump the compiled C++ to.

--- a/examples/array/Array.aui
+++ b/examples/array/Array.aui
@@ -1,3 +1,3 @@
 module Example.Array is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/array/Array.aum
+++ b/examples/array/Array.aum
@@ -21,7 +21,7 @@ module body Example.Array is
         return nil;
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let arropt: Option[Heap_Array[Boolean]] := Allocate_Array(3);
         case arropt of
         when Some(value: Heap_Array[Boolean]) do
@@ -40,6 +40,6 @@ module body Example.Array is
             when None do
                 skip;
         end case;
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/box/Box.aui
+++ b/examples/box/Box.aui
@@ -19,5 +19,5 @@ module Example.Box is
     generic [T: Free, R: Region]
     function Swap_Mut(boxref: WriteReference[Box[T], R], value: T): T;
 
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/box/Box.aum
+++ b/examples/box/Box.aum
@@ -76,7 +76,7 @@ module body Example.Box is
         pragma Foreign_Import(External_Name => "putchar");
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         -- Box a value, swap it, and unwrap it.
         let b: Option[Box[Integer_32]] := Make(101);
         case b of
@@ -135,6 +135,6 @@ module body Example.Box is
             when None do
                 Abort("Unexpected.");
         end case;
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/buffer/Buffer.aui
+++ b/examples/buffer/Buffer.aui
@@ -32,5 +32,5 @@ module Example.Buffer is
     --generic [T: Type, R: Region]
     --function Remove_Nth(buffer: WriteReference[Buffer[T], R], index: Natural_64): T;
 
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/buffer/Buffer.aum
+++ b/examples/buffer/Buffer.aum
@@ -114,7 +114,7 @@ module body Example.Buffer is
         pragma Foreign_Import(External_Name => "putchar");
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         -- Create a buffer of e's.
         let buf: Buffer[Integer_32] := Initialize(3, 101);
         borrow buf as bufref in rho do
@@ -126,6 +126,6 @@ module body Example.Buffer is
             Put_Character(first);
         end;
         Destroy_Buffer(buf);
-        return nil;
+        return root;
     end;
  end module body.

--- a/examples/concrete-typeclass/ConcreteTypeclass.aui
+++ b/examples/concrete-typeclass/ConcreteTypeclass.aui
@@ -1,3 +1,3 @@
 module Example.ConcreteTypeclass is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/concrete-typeclass/ConcreteTypeclass.aum
+++ b/examples/concrete-typeclass/ConcreteTypeclass.aum
@@ -18,7 +18,7 @@ module body Example.ConcreteTypeclass is
         return X;
     end;
 
-    function Main(): Unit is
-        return nil;
+    function Main(root: Root_Capability): Root_Capability is
+        return root;
     end;
 end module body.

--- a/examples/constant/Constant.aui
+++ b/examples/constant/Constant.aui
@@ -2,5 +2,5 @@ module Example.Constant is
     -- This constant is public, since it appears in the interface file.
     constant Rydberg_Constant : Double_Float;
 
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/constant/Constant.aum
+++ b/examples/constant/Constant.aum
@@ -5,7 +5,7 @@ module body Example.Constant is
     -- not the interface file.
     constant Pi : Double_Float := 3.14;
 
-    function Main(): Unit is
-        return nil;
+    function Main(root: Root_Capability): Root_Capability is
+        return root;
     end;
 end module body.

--- a/examples/ffi/FFI.aui
+++ b/examples/ffi/FFI.aui
@@ -1,3 +1,3 @@
 module Example.FFI is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/ffi/FFI.aum
+++ b/examples/ffi/FFI.aum
@@ -9,9 +9,9 @@ module body Example.FFI is
         pragma Foreign_Import(External_Name => "puts");
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         Put_Character(97);
         Put_String("Hello, world!");
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/fib/Fibonacci.aui
+++ b/examples/fib/Fibonacci.aui
@@ -1,5 +1,5 @@
 module Example.Fibonacci is
     ```The fibonacci function.```
     function Fibonacci(n: Natural_64): Natural_64;
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/fib/Fibonacci.aum
+++ b/examples/fib/Fibonacci.aum
@@ -8,8 +8,8 @@ module body Example.Fibonacci is
         end if;
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         Fibonacci(30);
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/generic-record/GenericRecord.aui
+++ b/examples/generic-record/GenericRecord.aui
@@ -4,5 +4,5 @@ module Example.GenericRecord is
         right: T;
     end;
 
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/generic-record/GenericRecord.aum
+++ b/examples/generic-record/GenericRecord.aum
@@ -1,7 +1,7 @@
 module body Example.GenericRecord is
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let R: Pair[Integer_32] := Pair(left => 10, right => 10);
         let V: Integer_32 := R.left;
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/generic-typeclass/GenericTypeclass.aui
+++ b/examples/generic-typeclass/GenericTypeclass.aui
@@ -1,3 +1,3 @@
 module Example.GenericTypeclass is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/generic-typeclass/GenericTypeclass.aum
+++ b/examples/generic-typeclass/GenericTypeclass.aum
@@ -25,7 +25,7 @@ module body Example.GenericTypeclass is
         end case;
     end;
 
-    function Main(): Unit is
-        return nil;
+    function Main(root: Root_Capability): Root_Capability is
+        return root;
     end;
 end module body.

--- a/examples/generic-union/GenericUnion.aui
+++ b/examples/generic-union/GenericUnion.aui
@@ -1,3 +1,3 @@
 module Example.GenericUnion is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/generic-union/GenericUnion.aum
+++ b/examples/generic-union/GenericUnion.aum
@@ -5,9 +5,9 @@ module body Example.GenericUnion is
             value: T;
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let S: Optional2[Integer_32] := Some2(value => 10);
         let N: Optional2[Integer_32] := None2();
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/haversine/Haversine.aui
+++ b/examples/haversine/Haversine.aui
@@ -1,3 +1,3 @@
 module Example.Haversine is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/haversine/Haversine.aum
+++ b/examples/haversine/Haversine.aum
@@ -34,7 +34,7 @@ module body Example.Haversine is
         return 2.0 * Earth_Radius * Arcsin(Sqrt(c));
     end;
 
-    function Main(): Unit is
-        return nil;
+    function Main(root: Root_Capability): Root_Capability is
+        return root;
     end;
 end module body.

--- a/examples/identity/Identity.aui
+++ b/examples/identity/Identity.aui
@@ -2,5 +2,5 @@ module Example.Identity is
     generic [T: Type]
     function Identity(value: T): T;
 
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/identity/Identity.aum
+++ b/examples/identity/Identity.aum
@@ -10,7 +10,7 @@ module body Example.Identity is
         return x;
     end;
 
-    function Main(): Unit is
-        return nil;
+    function Main(root: Root_Capability): Root_Capability is
+        return root;
     end;
 end module body.

--- a/examples/memory/Memory.aui
+++ b/examples/memory/Memory.aui
@@ -1,3 +1,3 @@
 module Example.Memory is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/memory/Memory.aum
+++ b/examples/memory/Memory.aum
@@ -9,7 +9,7 @@ import Austral.Memory (
 module body Example.Memory is
     pragma Unsafe_Module;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let opt: Option[Pointer[Integer_32]] := Allocate(10);
         case opt of
             when Some(value: Pointer[Integer_32]) do
@@ -18,6 +18,6 @@ module body Example.Memory is
               -- Do nothing.
               skip;
         end case;
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/named-argument/NamedArgument.aui
+++ b/examples/named-argument/NamedArgument.aui
@@ -1,4 +1,4 @@
 module Example.NamedArgument is
     function F(x: Boolean, y: Boolean): Unit;
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/named-argument/NamedArgument.aum
+++ b/examples/named-argument/NamedArgument.aum
@@ -3,8 +3,8 @@ module body Example.NamedArgument is
         return nil;
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         F(y => false, x => true);
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/pointer-to-record/PTR.aui
+++ b/examples/pointer-to-record/PTR.aui
@@ -1,3 +1,3 @@
 module Example.PTR is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/pointer-to-record/PTR.aum
+++ b/examples/pointer-to-record/PTR.aum
@@ -17,7 +17,7 @@ module body Example.PTR is
         pragma Foreign_Import(External_Name => "putchar");
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let r: R := R(X => 97);
         let optptr: Option[Pointer[R]] := Allocate(r);
         case optptr of
@@ -28,6 +28,6 @@ module body Example.PTR is
               -- Do nothing.
               skip;
         end case;
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/record/Record.aui
+++ b/examples/record/Record.aui
@@ -1,5 +1,5 @@
 module Example.Record is
     type R: Free;
 
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/record/Record.aum
+++ b/examples/record/Record.aum
@@ -3,9 +3,9 @@ module body Example.Record is
         X: Integer_32;
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let Rec : R := R(X => 10);
         let Y: Integer_32 := Rec.X;
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/ref-to-record/RTR.aui
+++ b/examples/ref-to-record/RTR.aui
@@ -1,3 +1,3 @@
 module Example.RTR is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/ref-to-record/RTR.aum
+++ b/examples/ref-to-record/RTR.aum
@@ -17,7 +17,7 @@ module body Example.RTR is
         pragma Foreign_Import(External_Name => "putchar");
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let r: R := R(X => 97);
         borrow r as r2 in rho do
             let char: Integer_32 := r2->X;
@@ -25,6 +25,6 @@ module body Example.RTR is
         end;
         let { X: Integer_32 } := r;
         Put_Character(X);
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/string/String.aui
+++ b/examples/string/String.aui
@@ -1,3 +1,3 @@
 module Example.String is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/string/String.aum
+++ b/examples/string/String.aum
@@ -9,13 +9,13 @@ module body Example.String is
         pragma Foreign_Import(External_Name => "puts");
     end;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let X: Fixed_Array[Natural_8] := "Hello, world!";
         let len: Natural_64 := Fixed_Array_Size(X);
         if len = 13 then
             Put_Character(X[0]);
             Put_String(X);
         end if;
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/type-alias/TypeAlias.aui
+++ b/examples/type-alias/TypeAlias.aui
@@ -1,3 +1,3 @@
 module Example.TypeAlias is
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/type-alias/TypeAlias.aum
+++ b/examples/type-alias/TypeAlias.aum
@@ -1,8 +1,8 @@
 module body Example.TypeAlias is
     type Num: Free is Integer_32;
 
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let N: Num := Num(10);
-        return nil;
+        return root;
     end;
 end module body.

--- a/examples/union/Union.aui
+++ b/examples/union/Union.aui
@@ -12,5 +12,5 @@ module Example.Union is
             value: Double_Float;
     end;
 
-    function Main(): Unit;
+    function Main(root: Root_Capability): Root_Capability;
 end module.

--- a/examples/union/Union.aum
+++ b/examples/union/Union.aum
@@ -1,5 +1,5 @@
 module body Example.Union is
-    function Main(): Unit is
+    function Main(root: Root_Capability): Root_Capability is
         let C : Color := Red();
         case C of
             when Red do
@@ -16,6 +16,6 @@ module body Example.Union is
             when Float(value: Double_Float) do
                 skip;
         end case;
-        return nil;
+        return root;
     end;
 end module body.

--- a/lib/BuiltIn.ml
+++ b/lib/BuiltIn.ml
@@ -12,6 +12,8 @@ let option_type_name = make_ident "Option"
 
 let option_type_qname = make_qident (pervasive_module_name, option_type_name, option_type_name)
 
+let root_cap_type_name = make_ident "Root_Capability"
+
 let pervasive_module =
   let i = make_ident in
   let option_type_def =
@@ -67,8 +69,18 @@ let pervasive_module =
         [ValueParameter (i "arr", Array (Integer (Unsigned, Width8), static_region))],
         Unit
       )
+  and root_cap_type_def =
+    let name = i "Root_Capability" in
+    (* type Root_Capability : Linear; *)
+    STypeAliasDefinition (
+        TypeVisOpaque,
+        name,
+        [],
+        LinearUniverse,
+        Unit
+    )
   in
-  let decls = [option_type_def; deref_def; fixed_array_size_def; abort_def] in
+  let decls = [option_type_def; deref_def; fixed_array_size_def; abort_def; root_cap_type_def] in
   SemanticModule {
       name = pervasive_module_name;
       decls = decls;
@@ -85,7 +97,8 @@ let pervasive_imports =
         ConcreteImport (make_ident "None", None);
         ConcreteImport (make_ident "Deref", None);
         ConcreteImport (make_ident "Fixed_Array_Size", None);
-        ConcreteImport (make_ident "Abort", None)
+        ConcreteImport (make_ident "Abort", None);
+        ConcreteImport (make_ident "Root_Capability", None)
       ]
     )
 

--- a/lib/BuiltIn.mli
+++ b/lib/BuiltIn.mli
@@ -10,6 +10,8 @@ val pervasive_module: semantic_module
 
 val option_type_name : identifier
 
+val root_cap_type_name : identifier
+
 val pervasive_imports: concrete_import_list
 
 (* Austral.Memory *)

--- a/lib/CppPrelude.ml
+++ b/lib/CppPrelude.ml
@@ -48,6 +48,8 @@ namespace Austral__Core {
 }
 
 namespace A_Austral__Pervasive {
+    typedef bool A_Root_Capability;
+
     enum A_Option_Tag {
         A_None, A_Some
     };


### PR DESCRIPTION
Currently entrypoint functions look like this:

```
function Main(): Unit;
```

For capability-based security to work, however, we need a linear type that represents the root capability of the capability poset. This root capability is passed to, and returned from, the entrypoint. Other user-defined capabilities are instantiated by passing e.g. a reference to the root capability, proving ownership.

So, for example, to acquire access to a filesystem capability, you might do:

```
let fs: Filesystem := Acquire_Filesystem(rootref);
```

The type of the root capability is called `Root_Capability` and is defined in the automatically-imported `Austral.Pervasive` module. Entrypoints now look like this:

```
function Main(root: Root_Capability): Root_Capability;
```