### PR TITLE
Add error type, better printing of errors in the terminal

### DIFF
--- a/lib/Cli.ml
+++ b/lib/Cli.ml
@@ -90,6 +90,6 @@ let main (args: string list): unit =
   try
     main' args;
     exit 0
-  with Programmer_error msg ->
-    Printf.eprintf "Error: %s" msg;
+  with Austral_error error ->
+    Printf.eprintf "%s" (render_error error);
     exit (-1)

--- a/lib/Error.ml
+++ b/lib/Error.ml
@@ -1,6 +1,81 @@
-exception Programmer_error of string
-exception Austral_parse_error of int * int
-exception Linearity_error of string
+open Span
 
-let err s =
-  raise (Programmer_error s)
+(* Represents an error. *)
+type error = Error of {
+      (* The code span that triggered the error. *)
+      span: span option;
+      (* The error data. *)
+      data: error_data;
+    }
+
+(* Represents the contents of an error. *)
+and error_data =
+  | GenericError of string
+  | ParseError
+
+(* Return the error description. *)
+let error_text (error_data: error_data): string =
+  match error_data with
+  | GenericError msg ->
+     msg
+  | ParseError ->
+     "Error during parse."
+
+(* Return the error title. *)
+let error_title (error_data: error_data): string =
+  match error_data with
+  | GenericError _ ->
+     "Generic Error"
+  | ParseError ->
+     "Parse Error"
+
+(* Render an error into a string for display in the terminal. *)
+let render_error (error: error) (code: string): string =
+  let (Error { span; data }) = error in
+  let span_text =
+    match span with
+    | Some (Span { filename; startp; endp }) ->
+       "  Location:\n"
+       ^ "    Filename: '" ^ filename ^ "'\n"
+       ^ "    From: " ^ (position_to_string startp) ^ "\n"
+       ^ "    To: " ^ (position_to_string endp) ^ "\n"
+    | None ->
+       ""
+  and code_text =
+    match span with
+    | Some span ->
+       "  Code:\n"
+       ^ (span_text code span)
+    | None ->
+       ""
+  in
+  "Error:\n"
+  ^ "  Title: " ^ (error_title data) ^ "\n"
+  ^ span_text
+  ^ "  Description:\n"
+  ^ (error_text data)
+  ^ code_text
+  ^ "\n"
+
+(* Throw an error encapsulated as an exception. *)
+exception Austral_error of error
+
+(* Convenience functions for throwing errors. *)
+
+(* Throw a generic error. *)
+let err (message: string) =
+  let e = Error {
+              span = None;
+              data = GenericError message
+            }
+  in
+  raise (Austral_error e)
+
+(* Throw a parse error. *)
+let raise_parse_error (span: span) =
+  let e = Error {
+              span = Some span;
+              data = ParseError
+            }
+  in
+  raise (Austral_error e)

--- a/lib/Linearity.ml
+++ b/lib/Linearity.ml
@@ -5,7 +5,7 @@ open Tast
 open Error
 
 let lerr msg =
-  raise (Linearity_error msg)
+  err msg
 
 let type_is_write_ref = function
   | WriteRef _ ->

--- a/lib/ParserInterface.ml
+++ b/lib/ParserInterface.ml
@@ -1,52 +1,16 @@
-open Lexing
 open Cst
+open Span
 open Error
 
-let colnum pos =
-  (pos.pos_cnum - pos.pos_bol) - 1
-
-let pos_string pos =
-  let l = string_of_int pos.pos_lnum
-  and c = string_of_int ((colnum pos) + 1) in
-  "line " ^ l ^ ", column " ^ c
-
-let position_text s lexbuf =
-  let pos = lexbuf.lex_curr_p
-  and lines = String.split_on_char '\n' s
-  and prefix = "    " in
-  let current_line_prefix = "    " ^ (string_of_int pos.pos_lnum) ^ " |"
-  in
-  let second_line_prefix = String.make (String.length current_line_prefix) ' ' in
-  let previous_line = if pos.pos_lnum = 1 then
-                        None
-                      else
-                        Some ((string_of_int (pos.pos_lnum - 1)) ^ " |" ^ (List.nth lines (pos.pos_lnum - 2)))
-  and nextline = if pos.pos_lnum = (List.length lines) then
-                   None
-                 else
-                   Some ((string_of_int (pos.pos_lnum + 1)) ^ " |" ^ (List.nth lines (pos.pos_lnum)))
-  and current_line = current_line_prefix ^ List.nth lines (pos.pos_lnum - 1) in
-  let second_line = String.init (String.length current_line) (fun i -> if i = (colnum pos) then '^' else ' ') in
-  let previous_str =
-    (match previous_line with
-     | Some s -> prefix ^ s ^ "\n"
-     | None -> "")
-    and nextline_str =
-      (match nextline with
-       | Some s -> prefix ^ s ^ "\n"
-       | None -> "")
-  in
-  previous_str ^ current_line ^ "\n" ^ second_line_prefix ^ second_line ^ "\n" ^ nextline_str
-
-let parse' f s (filename: string) =
-  let lexbuf = Lexing.from_string s in
+let parse' f (code: string) (filename: string) =
+  let lexbuf = Lexing.from_string code in
   Lexing.set_filename lexbuf filename;
   try
     f Lexer.token lexbuf
   with Parser.Error ->
-        err ("Parse error (" ^ (pos_string lexbuf.lex_curr_p) ^ "): \n" ^ (position_text s lexbuf))
-     | Programmer_error msg ->
-        err ("Parse error (" ^ (pos_string lexbuf.lex_curr_p) ^ "): \n" ^ msg ^ "\n" ^ (position_text s lexbuf))
+        raise_parse_error (from_lexbuf lexbuf)
+     | Austral_error error ->
+        raise (Austral_error error)
 
 let parse_module_int (s:string) (filename: string): concrete_module_interface  =
   parse' Parser.module_int s filename

--- a/lib/Span.ml
+++ b/lib/Span.ml
@@ -78,8 +78,8 @@ let span_text (code: string) (Span { startp; endp; _}): string =
         (line_num, line))
       collected_lines
   in
-  (* What's the largest line number? *)
-  let largest_line_num: int = List.fold_left max 0 (List.map (fun (ln, _) -> ln) numbered_lines) in
+  (* What's the size in characters of the largest line number? *)
+  let largest_line_num: int = List.fold_left max 0 (List.map (fun (ln, _) -> (String.length (string_of_int ln))) numbered_lines) in
   (* Render the lines. *)
   let rendered_lines: string list =
     List.map (fun (line_num, line) ->

--- a/lib/Span.mli
+++ b/lib/Span.mli
@@ -1,0 +1,28 @@
+open Lexing
+
+type position = Position of {
+      (* Lines range from 1 to infinity. *)
+      line: int;
+      (* Columns range from 0 to infinity. *)
+      column: int;
+    }
+
+type span = Span of {
+      filename: string;
+      startp: position;
+      endp: position;
+    }
+
+val from_lexbuf : lexbuf -> span
+
+(* Menhir has a special token, $loc, that evaluates to a (pos, pos) token. This
+   function takes that pair and returns a span. *)
+val from_loc : (Lexing.position * Lexing.position) -> span
+
+val position_to_string : position -> string
+
+val span_to_string : span -> string
+
+(* Given a string containing a code file, and a span, return the relevant lines
+   plus some context. *)
+val span_text : string -> span -> string


### PR DESCRIPTION
Fixes #36 and fixes #37.

Example error report:

```
Error:
  Title: Parse Error
  Location:
    Filename: 'examples/fib/Fibonacci.aum'
    From: line 13, column 4
    To: line 13, column 7
  Description:
    Error during parse.
  Code:
    11 |     function Main(root: Root_Capability): Root_Capability is
    12 |         Fibonacci(30);
    13 |         return root
    14 |     end;
    15 | end module body.
```