### PR TITLE
Simplify how paths interact with references

### DIFF
--- a/examples/box/Box.aum
+++ b/examples/box/Box.aum
@@ -3,7 +3,9 @@ import Austral.Memory (
     Allocate,
     Load,
     Store,
-    Deallocate
+    Deallocate,
+    Load_Read_Reference,
+    Load_Write_Reference
 );
 
 module body Example.Box is
@@ -46,27 +48,29 @@ module body Example.Box is
 
     generic [T: Free, R: Region]
     function Read_Free(boxref: Reference[Box[T], R]): T is
-        let ptr: Pointer[T] := boxref->pointer;
+        let ptrref: Reference[Pointer[T], R] := boxref->pointer;
+        let ptr: Pointer[T] := Deref(ptrref);
         let value: T := Load(ptr);
         return value;
     end;
 
     generic [T: Free, R: Region]
     function Store_Free(boxref: WriteReference[Box[T], R], value: T): Unit is
-        let ptr: Pointer[T] := boxref->pointer;
+        let ptrref: WriteReference[Pointer[T], R] := boxref->pointer;
+        let ptr: Pointer[T] := Deref_Write(ptrref);
         Store(ptr, value);
         return nil;
     end;
 
     generic [T: Type, R: Region]
     function Get_Value_Ref(boxref: Reference[Box[T], R]): Reference[T, R] is
-        let ref: Reference[T, R] := &boxref->pointer;
-        return ref;
+        let ptrref: Reference[Pointer[T], R] := boxref->pointer;
+        return Load_Read_Reference(ptrref);
     end;
 
     generic [T: Free, R: Region]
     function Swap_Mut(boxref: WriteReference[Box[T], R], value: T): T is
-        let ptr: Pointer[T] := boxref->pointer;
+        let ptr: Pointer[T] := Deref_Write(boxref->pointer);
         let old_value: T := Load(ptr);
         Store(ptr, value);
         return old_value;

--- a/examples/buffer/Buffer.aum
+++ b/examples/buffer/Buffer.aum
@@ -94,20 +94,20 @@ module body Example.Buffer is
 
     generic [T: Free, R: Region]
     function Buffer_Size(buffer: Reference[Buffer[T], R]): Natural_64 is
-        return buffer->size;
+        return Deref(buffer->size);
     end;
 
     -- Retrieval
 
     generic [T: Free, R: Region]
     function Nth_Free(buffer: Reference[Buffer[T], R], index: Natural_64): T is
-        let arr: Heap_Array[T] := buffer->array;
+        let arr: Heap_Array[T] := Deref(buffer->array);
         return arr[index];
     end;
 
     generic [T: Type, R: Region]
     function Nth_Ref(buffer: Reference[Buffer[T], R], index: Natural_64): Reference[T, R] is
-        return &buffer->array[index];
+        return buffer->array[index];
     end;
 
     function Put_Character(character: Integer_32): Integer_32 is

--- a/examples/ref-to-record/RTR.aum
+++ b/examples/ref-to-record/RTR.aum
@@ -20,7 +20,7 @@ module body Example.RTR is
     function Main(root: Root_Capability): Root_Capability is
         let r: R := R(X => 97);
         borrow r as r2 in rho do
-            let char: Integer_32 := r2->X;
+            let char: Integer_32 := Deref(r2->X);
             Put_Character(char);
         end;
         let { X: Integer_32 } := r;

--- a/lib/AbstractionPass.ml
+++ b/lib/AbstractionPass.ml
@@ -76,8 +76,6 @@ and abs_expr im expr =
      IfExpression (abs_expr im c, abs_expr im t, abs_expr im f)
   | CPath (_, e, es) ->
      Path (abs_expr im e, List.map (abs_path_elem im) es)
-  | CPathRef (_, e, es) ->
-     PathRef (abs_expr im e, List.map (abs_path_elem im) es)
   | CEmbed (_, ty, expr, args) ->
      Embed (qualify_typespec im ty, expr, List.map (abs_expr im) args)
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -47,7 +47,6 @@ and aexpr =
   | Negation of aexpr
   | IfExpression of aexpr * aexpr * aexpr
   | Path of aexpr * path_elem list
-  | PathRef of aexpr * path_elem list
   | Embed of qtypespec * string * aexpr list
 
 and abstract_when =

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -47,7 +47,6 @@ and aexpr =
   | Negation of aexpr
   | IfExpression of aexpr * aexpr * aexpr
   | Path of aexpr * path_elem list
-  | PathRef of aexpr * path_elem list
   | Embed of qtypespec * string * aexpr list
 
 and abstract_when =

--- a/lib/BuiltIn.ml
+++ b/lib/BuiltIn.ml
@@ -21,6 +21,7 @@ let pervasive_imports =
         ConcreteImport (make_ident "Some", None);
         ConcreteImport (make_ident "None", None);
         ConcreteImport (make_ident "Deref", None);
+        ConcreteImport (make_ident "Deref_Write", None);
         ConcreteImport (make_ident "Fixed_Array_Size", None);
         ConcreteImport (make_ident "Abort", None);
         ConcreteImport (make_ident "Root_Capability", None);
@@ -123,8 +124,31 @@ let memory_module =
         [ValueParameter (i "pointer", pointer_t qname)],
         Unit
       )
-  in
-  let allocate_array_def =
+  and load_read_ref_def =
+    let name = i "Load_Read_Reference" in
+    let qname = make_qident (memory_module_name, name, name) in
+    (* generic [T: Free, R: Region]
+       function Load_Read_Reference(ref: Reference[Pointer[T], R]): Reference[T, R] *)
+    SFunctionDeclaration (
+        VisPublic,
+        name,
+        [TypeParameter(i "T", TypeUniverse, qname); TypeParameter (i "R", RegionUniverse, qname)],
+        [ValueParameter (i "ref", ReadRef (NamedType (pointer_type_qname, [type_t qname], FreeUniverse), TyVar (TypeVariable (i "R", RegionUniverse, qname))))],
+        ReadRef (NamedType (pointer_type_qname, [type_t qname], FreeUniverse), TyVar (TypeVariable (i "R", RegionUniverse, qname)))
+      )
+  and load_write_ref_def =
+    let name = i "Load_Write_Reference" in
+    let qname = make_qident (memory_module_name, name, name) in
+    (* generic [T: Free, R: Region]
+       function Load_Write_Reference(ref: WriteReference[Pointer[T], R]): WriteReference[T, R] *)
+    SFunctionDeclaration (
+        VisPublic,
+        name,
+        [TypeParameter(i "T", TypeUniverse, qname); TypeParameter (i "R", RegionUniverse, qname)],
+        [ValueParameter (i "ref", WriteRef (NamedType (pointer_type_qname, [type_t qname], FreeUniverse), TyVar (TypeVariable (i "R", RegionUniverse, qname))))],
+        WriteRef (NamedType (pointer_type_qname, [type_t qname], FreeUniverse), TyVar (TypeVariable (i "R", RegionUniverse, qname)))
+      )
+  and allocate_array_def =
     let name = i "Allocate_Array" in
     let qname = make_qident (memory_module_name, name, name) in
     (* generic T: Type
@@ -180,6 +204,8 @@ let memory_module =
       load_def;
       store_def;
       deallocate_def;
+      load_read_ref_def;
+      load_write_ref_def;
       allocate_array_def;
       resize_array_def;
       deallocate_array_def;

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -241,14 +241,20 @@ let rec gen_exp (mn: module_name) (e: texpr): cpp_expr =
              ("tag", union_tag_value ty case_name);
              ("data", CStructInitializer [(gen_ident case_name, args)])
            ])
-  | TPath (e, elems) ->
-     gen_path mn (g e) (List.rev elems)
-  | TPathRef (e, elems, _, is_pointer) ->
-     let p = gen_path mn (g e) (List.rev elems) in
-     if is_pointer then
-       p
-     else
-       CAddressOf p
+  | TPath { head; elems; _ } ->
+     let p = gen_path mn (g head) (List.rev elems) in
+     (match (get_type head) with
+      (* References get wrapped in the address-of operator '&' to match C
+         semantics. A path of the form `x.y`, where `x` is a reference, if
+         compiled straight to C would evaluate to the type of `y`, rather than
+         the type reference-to-`y`. So we turn it into `&x.y` so evaluates to
+         reference-to-`y`. *)
+      | ReadRef _ ->
+         CAddressOf p
+      | WriteRef _ ->
+         CAddressOf p
+      | _ ->
+         p)
   | TEmbed (ty, expr, args) ->
      CEmbed (gen_type ty, expr, List.map g args)
 

--- a/lib/Cpp.ml
+++ b/lib/Cpp.ml
@@ -10,6 +10,7 @@ type cpp_ty =
   | CPointer of cpp_ty
   | CStructType of cpp_struct
   | CUnionType of cpp_slot list
+[@@deriving show]
 and cpp_slot = CSlot of string * cpp_ty
 and cpp_struct = CStruct of string option * cpp_slot list
 

--- a/lib/Cpp.mli
+++ b/lib/Cpp.mli
@@ -10,6 +10,7 @@ type cpp_ty =
   | CPointer of cpp_ty
   | CStructType of cpp_struct
   | CUnionType of cpp_slot list
+[@@deriving show]
 and cpp_slot = CSlot of string * cpp_ty
 and cpp_struct = CStruct of string option * cpp_slot list
 

--- a/lib/CppPrelude.ml
+++ b/lib/CppPrelude.ml
@@ -85,6 +85,16 @@ namespace A_Austral__Memory {
         return false;
     }
 
+    template<typename T>
+    T* A_Load_Read_Reference(T** ref) {
+        return *ref;
+    }
+
+    template<typename T>
+    T* A_Load_Write_Reference(T** ref) {
+        return *ref;
+    }
+
     using namespace A_Austral__Pervasive;
 
     template <typename T>

--- a/lib/Cst.ml
+++ b/lib/Cst.ml
@@ -80,7 +80,6 @@ and cexpr =
   | CNegation of span * cexpr
   | CIfExpression of span * cexpr * cexpr * cexpr
   | CPath of span * cexpr * concrete_path_elem list
-  | CPathRef of span * cexpr * concrete_path_elem list
   | CEmbed of span * typespec * string * cexpr list
 
 and cstmt =

--- a/lib/Cst.mli
+++ b/lib/Cst.mli
@@ -79,7 +79,6 @@ and cexpr =
   | CNegation of span * cexpr
   | CIfExpression of span * cexpr * cexpr * cexpr
   | CPath of span * cexpr * concrete_path_elem list
-  | CPathRef of span * cexpr * concrete_path_elem list
   | CEmbed of span * typespec * string * cexpr list
 
 and cstmt =

--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -120,7 +120,6 @@ rule token = parse
   | "->" { HYPHEN_RIGHT }
   | "=>" { RIGHT_ARROW }
   | ":=" { ASSIGN }
-  | "&" { ADDRESS_OF }
   (* Strings and docstrings *)
   | "\"\"\"" { read_triple_string lexbuf }
   | '"' { read_string lexbuf }

--- a/lib/Linearity.ml
+++ b/lib/Linearity.ml
@@ -58,7 +58,7 @@ let rec count_appearances (name: identifier) (expr: texpr) =
      sum (List.map (fun (_, e) -> ca e) args)
   | TUnionConstructor (_, _, args) ->
      sum (List.map (fun (_, e) -> ca e) args)
-  | TPath (e, elems) ->
+  | TPath { head; elems; _ } ->
      (* All paths end in a free value. If the head of the path is the variable
         we're counting, we don't count this as an appearance. This is for
         programmer ergonomics. It's also so that if we have a record `r` with
@@ -72,29 +72,11 @@ let rec count_appearances (name: identifier) (expr: texpr) =
        (* Count the number of appearances of this variable in the expression,
           unless the expression is just a bare variable. So `f(x).y` will count
           but not `x.y`. *)
-       (match e with
+       (match head with
         | TVariable _ ->
            0
         | _ ->
-           ca e)
-     in
-     let ca_path elem =
-       (match elem with
-        | TSlotAccessor _ ->
-           0
-        | TPointerSlotAccessor _ ->
-           0
-        | TArrayIndex (ie, _) ->
-           count_appearances name ie)
-     in
-     e' + (sum (List.map ca_path elems))
-  | TPathRef (e, elems, _, _) ->
-     let e' =
-       (match e with
-        | TVariable _ ->
-           0
-        | _ ->
-           ca e)
+           ca head)
      in
      let ca_path elem =
        (match elem with

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -76,7 +76,6 @@ open Span
 %token HYPHEN_RIGHT
 %token RIGHT_ARROW
 %token ASSIGN
-%token ADDRESS_OF
 /* Strings and docstrings */
 %token <string> STRING_CONSTANT
 %token <string> TRIPLE_STRING_CONSTANT
@@ -434,7 +433,6 @@ intrinsic:
 
 compound_expression:
   | path { $1 }
-  | path_ref { $1 }
   | atomic_expression comp_op atomic_expression { CComparison (from_loc $loc, $2, $1, $3) }
   | atomic_expression AND atomic_expression { CConjunction (from_loc $loc, $1, $3) }
   | atomic_expression OR atomic_expression { CDisjunction (from_loc $loc, $1, $3) }
@@ -445,10 +443,6 @@ compound_expression:
 
 path:
   | initial=atomic_expression elems=path_rest+ { CPath (from_loc $loc, initial, elems) }
-  ;
-
-path_ref:
-  | ADDRESS_OF initial=atomic_expression elems=path_rest+ { CPathRef (from_loc $loc, initial, elems) }
   ;
 
 path_rest:

--- a/lib/Pervasive.ml
+++ b/lib/Pervasive.ml
@@ -12,6 +12,9 @@ module Austral.Pervasive is
     generic [T: Free, R: Region]
     function Deref(ref: Reference[T, R]): T;
 
+    generic [T: Free, R: Region]
+    function Deref_Write(ref: WriteReference[T, R]): T;
+
     generic [T: Type]
     function Fixed_Array_Size(arr: Fixed_Array[T]): Natural_64;
 
@@ -58,6 +61,11 @@ let pervasive_body_source = {code|
 module body Austral.Pervasive is
     generic [T: Free, R: Region]
     function Deref(ref: Reference[T, R]): T is
+        return @embed(T, "*$1", ref);
+    end;
+
+    generic [T: Free, R: Region]
+    function Deref_Write(ref: WriteReference[T, R]): T is
         return @embed(T, "*$1", ref);
     end;
 

--- a/lib/Tast.ml
+++ b/lib/Tast.ml
@@ -63,8 +63,11 @@ and texpr =
   | TIfExpression of texpr * texpr * texpr
   | TRecordConstructor of ty * (identifier * texpr) list
   | TUnionConstructor of ty * identifier * (identifier * texpr) list
-  | TPath of texpr * typed_path_elem list
-  | TPathRef of texpr * typed_path_elem list * ty * bool
+  | TPath of {
+      head: texpr;
+      elems: typed_path_elem list;
+      ty: ty
+    }
   | TEmbed of ty * string * texpr list
 
 and typed_when =
@@ -143,11 +146,7 @@ let rec get_type = function
      ty
   | TUnionConstructor (ty, _, _) ->
      ty
-  | TPath (_, elems) ->
-     assert ((List.length elems) > 0);
-     let last = List.nth elems ((List.length elems) - 1) in
-     path_elem_type last
-  | TPathRef (_, _, ty, _) ->
+  | TPath { ty; _ } ->
      ty
   | TEmbed (ty, _, _) ->
      ty

--- a/lib/Tast.mli
+++ b/lib/Tast.mli
@@ -62,8 +62,11 @@ and texpr =
   | TIfExpression of texpr * texpr * texpr
   | TRecordConstructor of ty * (identifier * texpr) list
   | TUnionConstructor of ty * identifier * (identifier * texpr) list
-  | TPath of texpr * typed_path_elem list
-  | TPathRef of texpr * typed_path_elem list * ty * bool
+  | TPath of {
+      head: texpr;
+      elems: typed_path_elem list;
+      ty: ty
+    }
   | TEmbed of ty * string * texpr list
 
 and typed_when =

--- a/lib/TypeParser.ml
+++ b/lib/TypeParser.ml
@@ -55,15 +55,11 @@ let parse_built_in_type name args =
   | "WriteReference" ->
      (match args with
       | [ty; ty'] ->
-         let u = type_universe ty in
-         if ((u = LinearUniverse) || (u = TypeUniverse)) then
-           let u' = type_universe ty' in
-           if (u' = RegionUniverse) then
-             Some (WriteRef (ty, ty'))
-           else
-             err "WriteReference error: Not a region"
+         let u' = type_universe ty' in
+         if (u' = RegionUniverse) then
+           Some (WriteRef (ty, ty'))
          else
-           err "Writable references can only point to linear types."
+           err "WriteReference error: Not a region"
       | _ ->
          err "Invalid WriteReference type specifier.")
   | _ ->

--- a/lib/TypeSystem.ml
+++ b/lib/TypeSystem.ml
@@ -12,7 +12,7 @@ let type_universe = function
   | Array (_, _) -> FreeUniverse
   | RegionTy _ -> RegionUniverse
   | ReadRef _ -> FreeUniverse
-  | WriteRef _ -> LinearUniverse
+  | WriteRef _ -> FreeUniverse
   | TyVar (TypeVariable (_, u, _)) -> u
 
 let type_arguments = function


### PR DESCRIPTION
Fixes #58

Formerly there was a special case where a path of the form `x.y` where `x` is a reference and `y` is a `Pointer` would have a type `Pointer[T]` instead of `Reference[Pointer[T], R]`. This special case has been removed.