### PR TITLE
Compile type aliases to single-value structs

### DIFF
--- a/lib/Compiler.ml
+++ b/lib/Compiler.ml
@@ -98,7 +98,7 @@ and is_root_cap_type = function
 
 let entrypoint_code mn i =
   let f = (gen_module_name mn) ^ "::" ^ (gen_ident i) in
-  "int main() {\n    " ^ f ^ "(false);\n    return 0;\n}\n"
+  "int main() {\n    " ^ f ^ "((A_Austral__Pervasive::A_Root_Capability) { .value = false });\n    return 0;\n}\n"
 
 let compile_entrypoint c mn i =
   let qi = make_qident (mn, i, i) in

--- a/lib/CppRenderer.ml
+++ b/lib/CppRenderer.ml
@@ -198,7 +198,7 @@ and render_expr = function
   | (CCast (e, t)) ->
      let e' = render_expr e
      and t' = render_type t in
-     paren ((paren t') ^ (paren e'))
+     paren ((paren t') ^ " " ^ e')
   | (CArithmetic (op, l, r)) ->
      paren ((e l) ^ " " ^ render_arith op ^ " " ^ (e r))
   | (CComparison (op, l, r)) ->

--- a/lib/Linearity.ml
+++ b/lib/Linearity.ml
@@ -58,6 +58,8 @@ let rec count_appearances (name: identifier) (expr: texpr) =
      sum (List.map (fun (_, e) -> ca e) args)
   | TUnionConstructor (_, _, args) ->
      sum (List.map (fun (_, e) -> ca e) args)
+  | TTypeAliasConstructor (_, e) ->
+     ca e
   | TPath { head; elems; _ } ->
      (* All paths end in a free value. If the head of the path is the variable
         we're counting, we don't count this as an appearance. This is for

--- a/lib/Monomorphize.ml
+++ b/lib/Monomorphize.ml
@@ -219,6 +219,10 @@ let rec monomorphize_expr (tbl: mono_tbl) (expr: texpr): (mexpr * mono_tbl) =
      let (ty, tbl) = strip_and_mono tbl ty in
      let (args, tbl) = monomorphize_named_expr_list tbl args in
      (MUnionConstructor (ty, case_name, args), tbl)
+  | TTypeAliasConstructor (ty, expr) ->
+     let (ty, tbl) = strip_and_mono tbl ty in
+     let (expr, tbl) = monomorphize_expr tbl expr in
+     (MTypeAliasConstructor (ty, expr), tbl)
   | TPath { head; elems; ty } ->
      let (ty, tbl) = strip_and_mono tbl ty in
      let (head, tbl) = monomorphize_expr tbl head in
@@ -427,6 +431,10 @@ let rec replace_tyvars_expr (bindings: type_bindings) (expr: texpr): texpr =
      let ty = replace_variables bindings ty
      and args = List.map (fun (n, e) -> (n, replace_tyvars_expr bindings e)) args in
      TUnionConstructor (ty, case_name, args)
+  | TTypeAliasConstructor (ty, expr) ->
+     let ty = replace_variables bindings ty
+     and expr = replace_tyvars_expr bindings expr in
+     TTypeAliasConstructor (ty, expr)
   | TPath { head; elems; ty } ->
      let head = replace_tyvars_expr bindings head
      and elems = List.map (replace_tyvars_path bindings) elems

--- a/lib/Mtast.ml
+++ b/lib/Mtast.ml
@@ -52,6 +52,7 @@ and mexpr =
   | MIfExpression of mexpr * mexpr * mexpr
   | MRecordConstructor of mono_ty * (identifier * mexpr) list
   | MUnionConstructor of mono_ty * identifier * (identifier * mexpr) list
+  | MTypeAliasConstructor of mono_ty * mexpr
   | MPath of {
       head: mexpr;
       elems: mtyped_path_elem list;

--- a/lib/Mtast.mli
+++ b/lib/Mtast.mli
@@ -57,6 +57,7 @@ and mexpr =
   | MIfExpression of mexpr * mexpr * mexpr
   | MRecordConstructor of mono_ty * (identifier * mexpr) list
   | MUnionConstructor of mono_ty * identifier * (identifier * mexpr) list
+  | MTypeAliasConstructor of mono_ty * mexpr
   | MPath of {
       head: mexpr;
       elems: mtyped_path_elem list;

--- a/lib/Tast.ml
+++ b/lib/Tast.ml
@@ -65,6 +65,7 @@ and texpr =
   | TIfExpression of texpr * texpr * texpr
   | TRecordConstructor of ty * (identifier * texpr) list
   | TUnionConstructor of ty * identifier * (identifier * texpr) list
+  | TTypeAliasConstructor of ty * texpr
   | TPath of {
       head: texpr;
       elems: typed_path_elem list;
@@ -149,6 +150,8 @@ let rec get_type = function
   | TRecordConstructor (ty, _) ->
      ty
   | TUnionConstructor (ty, _, _) ->
+     ty
+  | TTypeAliasConstructor (ty, _) ->
      ty
   | TPath { ty; _ } ->
      ty

--- a/lib/Tast.mli
+++ b/lib/Tast.mli
@@ -63,6 +63,7 @@ and texpr =
   | TIfExpression of texpr * texpr * texpr
   | TRecordConstructor of ty * (identifier * texpr) list
   | TUnionConstructor of ty * identifier * (identifier * texpr) list
+  | TTypeAliasConstructor of ty * texpr
   | TPath of {
       head: texpr;
       elems: typed_path_elem list;

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -415,7 +415,7 @@ and augment_typealias_callable name typarams universe asserted_ty definition_ty 
   let (bindings', rt'') = handle_return_type_polymorphism (local_name name) typarams rt' asserted_ty in
   (* Check: the set of bindings equals the set of type parameters *)
   check_bindings typarams (merge_bindings bindings bindings');
-  TCast (arg, rt'')
+  TTypeAliasConstructor (rt'', arg)
 
 and augment_record_constructor (name: qident) (typarams: type_parameter list) (universe: universe) (slots: typed_slot list) (asserted_ty: ty option) (args: typed_arglist) =
   (* Check: the argument list must be named *)
@@ -1025,6 +1025,8 @@ and is_constant = function
      List.for_all (fun (_, v) -> is_constant v) values
   | TUnionConstructor (_, _, values) ->
      List.for_all (fun (_, v) -> is_constant v) values
+  | TTypeAliasConstructor (_, e) ->
+     is_constant e
   | TPath { head; elems; _ } ->
      (is_constant head) && (List.for_all is_path_elem_constant elems)
   | TEmbed _ ->


### PR DESCRIPTION
Fix #121 