### PR TITLE
 Update examples to use `Allocate_Array` instead of `Allocate`

### DIFF
--- a/examples/box/Box.aui
+++ b/examples/box/Box.aui
@@ -2,7 +2,7 @@ module Example.Box is
     type Box[T: Type]: Linear;
 
     generic [T: Type]
-    function Make(val: T): Option[Box[T]];
+    function Make(val: T): Either[Box[T], T];
 
     generic [T: Type]
     function Unbox(box: Box[T]): T;

--- a/examples/box/Box.aum
+++ b/examples/box/Box.aum
@@ -1,6 +1,6 @@
 import Austral.Memory (
     Pointer,
-    Allocate,
+    Allocate_Array,
     Load,
     Store,
     Deallocate,
@@ -16,16 +16,18 @@ module body Example.Box is
     end;
 
     generic [T: Type]
-    function Make(val: T): Option[Box[T]] is
-        let ptr: Option[Pointer[T]] := Allocate(val);
+    function Make(val: T): Either[Box[T], T] is
+        let ptr: Option[Pointer[T]] := Allocate_Array(sizeof(T));
         case ptr of
             when Some(value: Pointer[T]) do
+                Store(value, val);
                 let box: Box[T] := Box(pointer => value);
-                let boxopt: Option[Box[T]] := Some(value => box);
-                return boxopt;
+                let left: Either[Box[T], T] := Left(left => box);
+                return left;
             when None do
-                let boxopt: Option[Box[T]] := None();
-                return boxopt;
+                -- Allocation failed, return the object we tried to box.
+                let right: Either[Box[T], T] := Right(right => val);
+                return right;
         end case;
     end;
 
@@ -83,61 +85,61 @@ module body Example.Box is
 
     function Main(root: Root_Capability): Root_Capability is
         -- Box a value, swap it, and unwrap it.
-        let b: Option[Box[Integer_32]] := Make('e');
+        let b: Either[Box[Integer_32], Integer_32] := Make('e');
         case b of
-            when Some(value: Box[Integer_32]) do
-                let newbox: Box[Integer_32] := Swap_Free(value, 'a');
+            when Left(left: Box[Integer_32]) do
+                let newbox: Box[Integer_32] := Swap_Free(left, 'a');
                 let contents: Integer_32 := Unbox(newbox);
                 Put_Character(contents);
-            when None do
+            when Right(right: Integer_32) do
                 Abort("Unexpected.");
         end case;
         -- Box a value, read_free it and unbox it.
-        let b2: Option[Box[Integer_32]] := Make('a');
+        let b2: Either[Box[Integer_32], Integer_32] := Make('a');
         case b2 of
-            when Some(value: Box[Integer_32]) do
-                borrow value as value2 in rho do
+            when Left(left: Box[Integer_32]) do
+                borrow left as value2 in rho do
                     let contents: Integer_32 := Read_Free(value2);
                     Put_Character(contents);
                 end;
-                Unbox(value);
-            when None do
+                Unbox(left);
+            when Right(right: Integer_32) do
                 Abort("Unexpected.");
         end case;
         -- Box a value, store a new one through a mutable reference, and unbox it.
-        let b3: Option[Box[Integer_32]] := Make('e');
+        let b3: Either[Box[Integer_32], Integer_32] := Make('e');
         case b3 of
-            when Some(value: Box[Integer_32]) do
-                borrow! value as value2 in rho do
+            when Left(left: Box[Integer_32]) do
+                borrow! left as value2 in rho do
                     Store_Free(value2, 'a');
                 end;
-                let contents: Integer_32 := Unbox(value);
+                let contents: Integer_32 := Unbox(left);
                 Put_Character(contents);
-            when None do
+            when Right(right: Integer_32) do
                 Abort("Unexpected.");
         end case;
         -- Box a value, load it through a reference, and unbox it.
-        let b4: Option[Box[Integer_32]] := Make('a');
+        let b4: Either[Box[Integer_32], Integer_32] := Make('a');
         case b4 of
-            when Some(value: Box[Integer_32]) do
-                borrow value as boxref in rho do
+            when Left(left: Box[Integer_32]) do
+                borrow left as boxref in rho do
                     let valueref: Reference[Integer_32, rho] := Get_Value_Ref(boxref);
                     let contents: Integer_32 := !(valueref);
                     Put_Character(contents);
                 end;
-                Unbox(value);
-            when None do
+                Unbox(left);
+            when Right(right: Integer_32) do
                 Abort("Unexpected.");
         end case;
         -- Box a value, swap it through a mutable reference, and unbox it.
-        let b5: Option[Box[Integer_32]] := Make('e');
+        let b5: Either[Box[Integer_32], Integer_32] := Make('e');
         case b5 of
-            when Some(value: Box[Integer_32]) do
-                borrow! value as boxmutref in rho do
+            when Left(left: Box[Integer_32]) do
+                borrow! left as boxmutref in rho do
                     Swap_Mut(boxmutref, 'a');
                 end;
-                Put_Character(Unbox(value));
-            when None do
+                Put_Character(Unbox(left));
+            when Right(right: Integer_32) do
                 Abort("Unexpected.");
         end case;
         return root;

--- a/examples/generic-typeclass/GenericTypeclass.aum
+++ b/examples/generic-typeclass/GenericTypeclass.aum
@@ -1,4 +1,4 @@
-import Austral.Memory (Pointer, Allocate);
+import Austral.Memory (Pointer, Allocate_Array);
 
 module body Example.GenericTypeclass is
     pragma Unsafe_Module;
@@ -15,7 +15,7 @@ module body Example.GenericTypeclass is
     end;
 
     function Pointer_To_Integer(): Integer_32 is
-        let opt: Option[Pointer[Integer_32]] := Allocate(10);
+        let opt: Option[Pointer[Integer_32]] := Allocate_Array(sizeof(Integer_32));
         case opt of
           when Some(value: Pointer[Integer_32]) do
             let X: Integer_32 := To_Integer(value);

--- a/examples/memory/Memory.aum
+++ b/examples/memory/Memory.aum
@@ -1,6 +1,6 @@
 import Austral.Memory (
     Pointer,
-    Allocate,
+    Allocate_Array,
     Load,
     Store,
     Deallocate
@@ -10,7 +10,7 @@ module body Example.Memory is
     pragma Unsafe_Module;
 
     function Main(root: Root_Capability): Root_Capability is
-        let opt: Option[Pointer[Integer_32]] := Allocate(10);
+        let opt: Option[Pointer[Integer_32]] := Allocate_Array(sizeof(Integer_32));
         case opt of
             when Some(value: Pointer[Integer_32]) do
               Deallocate(value);

--- a/examples/pointer-to-record/PTR.aum
+++ b/examples/pointer-to-record/PTR.aum
@@ -1,6 +1,6 @@
 import Austral.Memory (
     Pointer,
-    Allocate,
+    Allocate_Array,
     Load,
     Store,
     Deallocate
@@ -19,9 +19,10 @@ module body Example.PTR is
 
     function Main(root: Root_Capability): Root_Capability is
         let r: R := R(X => 97);
-        let optptr: Option[Pointer[R]] := Allocate(r);
+        let optptr: Option[Pointer[R]] := Allocate_Array(sizeof(R));
         case optptr of
             when Some(value: Pointer[R]) do
+                Store(value, r);
                 Put_Character(value->X);
                 Deallocate(value);
             when None do

--- a/examples/ref-to-record/RTR.aum
+++ b/examples/ref-to-record/RTR.aum
@@ -1,11 +1,3 @@
-import Austral.Memory (
-    Pointer,
-    Allocate,
-    Load,
-    Store,
-    Deallocate
-);
-
 module body Example.RTR is
     pragma Unsafe_Module;
 

--- a/lib/Compiler.ml
+++ b/lib/Compiler.ml
@@ -17,8 +17,8 @@ open Error
 open Util
 open Combined
 open Linked
-open Mtast
-open Monomorphize
+(*open Mtast
+open Monomorphize*)
 open Filename
 
 let append_import_to_interface (ci: concrete_module_interface) (import: concrete_import_list): concrete_module_interface =
@@ -62,8 +62,8 @@ let rec compile_mod c (ModuleSource { int_filename; int_code; body_filename; bod
   let (env, linked): (env * linked_module) = extract env combined int_file_id body_file_id in
   let typed: typed_module = augment_module env linked in
   let env: env = extract_bodies env typed in
-  let (env, mono): (env * mono_module) = monomorphize env typed in
-  let _ = mono in
+  (*let (env, mono): (env * mono_module) = monomorphize env typed in
+  let _ = mono in *)
   let cpp = gen_module typed in
   let code = render_module cpp in
   Compiler (env, (compiler_code c) ^ "\n" ^ code)


### PR DESCRIPTION
Fix #153 