### PR TITLE
Fix handling return type polymorphism

### DIFF
--- a/examples/box/Box.aum
+++ b/examples/box/Box.aum
@@ -53,8 +53,7 @@ module body Example.Box is
     function Read_Free(boxref: Reference[Box[T], R]): T is
         let ptrref: Reference[Pointer[T], R] := boxref->pointer;
         let ptr: Pointer[T] := !ptrref;
-        let value: T := Load(ptr);
-        return value;
+        return Load(ptr);
     end;
 
     generic [T: Free, R: Region]

--- a/examples/memory/Memory.aum
+++ b/examples/memory/Memory.aum
@@ -13,10 +13,7 @@ module body Example.Memory is
     function Main(root: Root_Capability): Root_Capability is
         let ptr: Pointer[Integer_32] := Allocate(sizeof(Integer_32));
         let null: Pointer[Integer_32] := Null_Pointer();
-        if ptr = null then
-            -- Do nothing.
-            skip;
-        else
+        if ptr /= null then
             Deallocate(ptr);
         end if;
         return root;

--- a/lib/Type.ml
+++ b/lib/Type.ml
@@ -26,7 +26,7 @@ type type_parameter = TypeParameter of identifier * universe * qident
 [@@deriving show]
 
 type type_var = TypeVariable of identifier * universe * qident
-[@@deriving eq, show]
+[@@deriving (eq, show)]
 
 type ty =
   | Unit

--- a/lib/Type.mli
+++ b/lib/Type.mli
@@ -25,7 +25,7 @@ type type_parameter = TypeParameter of identifier * universe * qident
 [@@deriving show]
 
 type type_var = TypeVariable of identifier * universe * qident
-[@@deriving eq]
+[@@deriving (eq, show)]
 
 type ty =
   | Unit

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -674,35 +674,18 @@ and make_substs (bindings: type_bindings) (typarams: type_parameter list): (iden
   List.filter_map f typarams
 
 and handle_return_type_polymorphism (name: identifier) (params: value_parameter list) (rt: ty) (asserted_ty: ty option) (bindings: type_bindings): (type_bindings * ty) =
-  let _ = print_endline "---BEGIN---" in
-  print_endline ("Function " ^ (ident_string name));
-  (*print_endline "---BEGIN---";
-  print_endline (ident_string name);
-  print_endline (String.concat ", " (List.map show_type_parameter typarams));
-  print_endline (show_ty rt);
-  print_endline (show_bindings bindings);*)
-  let retval =
-    if is_return_type_polymorphic params rt then
-      let _ = print_endline ("BOOL: is polymorphic on the return type") in
-      match asserted_ty with
-      | (Some asserted_ty') ->
-         let bindings' = match_type rt asserted_ty' in
-         let bindings'' = merge_bindings bindings bindings' in
-         (bindings'', replace_variables bindings'' rt)
-      | None ->
-         err ("Callable '"
-              ^ (ident_string name)
-              ^ "' is polymorphic in the return type but has no asserted type.")
-    else
-      let _ = print_endline ("BOOL: is not polymorphic") in
-      print_endline "Bindings:";
-      print_endline (show_bindings bindings);
-      print_endline ("RT Before:\n" ^ (show_ty rt));
-      print_endline ("RT After:\n" ^ (show_ty (replace_variables bindings rt)));
-      (empty_bindings, replace_variables bindings rt)
-  in
-  print_endline "---END---";
-  retval
+  if is_return_type_polymorphic params rt then
+    match asserted_ty with
+    | (Some asserted_ty') ->
+       let bindings' = match_type rt asserted_ty' in
+       let bindings'' = merge_bindings bindings bindings' in
+       (bindings'', replace_variables bindings'' rt)
+    | None ->
+       err ("Callable '"
+            ^ (ident_string name)
+            ^ "' is polymorphic in the return type but has no asserted type.")
+  else
+    (empty_bindings, replace_variables bindings rt)
 
 (* Given a function's parameter list and return type, check if the return type
    of a function is polymorphic. *)

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -469,7 +469,7 @@ and augment_function_call (id: decl_id) name typarams params rt asserted_ty args
   let bindings = check_argument_list params arguments in
   (* Use the bindings to get the effective return type *)
   let rt' = replace_variables bindings rt in
-  let (bindings', rt'') = handle_return_type_polymorphism (local_name name) typarams rt' asserted_ty bindings in
+  let (bindings', rt'') = handle_return_type_polymorphism (local_name name) params rt' asserted_ty bindings in
   (* Check: the set of bindings equals the set of type parameters *)
   let bindings'' = merge_bindings bindings bindings' in
   check_bindings typarams bindings'';
@@ -496,7 +496,7 @@ and augment_typealias_callable name typarams universe asserted_ty definition_ty 
              )
   in
   let rt' = replace_variables bindings rt in
-  let (bindings', rt'') = handle_return_type_polymorphism (local_name name) typarams rt' asserted_ty bindings in
+  let (bindings', rt'') = handle_return_type_polymorphism (local_name name) params rt' asserted_ty bindings in
   (* Check: the set of bindings equals the set of type parameters *)
   check_bindings typarams (merge_bindings bindings bindings');
   TTypeAliasConstructor (rt'', arg)
@@ -528,7 +528,7 @@ and augment_record_constructor (name: qident) (typarams: type_parameter list) (u
                         universe)
     in
     let rt' = replace_variables bindings rt in
-    let (bindings', rt'') = handle_return_type_polymorphism (local_name name) typarams rt' asserted_ty bindings in
+    let (bindings', rt'') = handle_return_type_polymorphism (local_name name) params rt' asserted_ty bindings in
     (* Check: the set of bindings equals the set of type parameters *)
     check_bindings typarams (merge_bindings bindings bindings');
     (* Check the resulting type is in the correct universe *)
@@ -565,7 +565,7 @@ and augment_union_constructor (type_name: qident) (typarams: type_parameter list
                         universe)
     in
     let rt' = replace_variables bindings rt in
-    let (bindings', rt'') = handle_return_type_polymorphism case_name typarams rt' asserted_ty bindings in
+    let (bindings', rt'') = handle_return_type_polymorphism case_name params rt' asserted_ty bindings in
     (* Check: the set of bindings equals the set of type parameters *)
     check_bindings typarams (merge_bindings bindings bindings');
     (* Check the resulting type is in the correct universe *)
@@ -586,7 +586,7 @@ and augment_method_call (env: env) (source_module_name: module_name) (typeclass_
   let bindings = check_argument_list params arguments in
   (* Use the bindings to get the effective return type *)
   let rt' = replace_variables bindings rt in
-  let (bindings', rt'') = handle_return_type_polymorphism (local_name callable_name) [typaram] rt' asserted_ty bindings in
+  let (bindings', rt'') = handle_return_type_polymorphism (local_name callable_name) params rt' asserted_ty bindings in
   let bindings'' = merge_bindings bindings bindings' in
   (* Check: the set of bindings equals the set of type parameters *)
   check_bindings [typaram] bindings'';
@@ -673,27 +673,58 @@ and make_substs (bindings: type_bindings) (typarams: type_parameter list): (iden
   in
   List.filter_map f typarams
 
-and handle_return_type_polymorphism (name: identifier) (typarams: type_parameter list) (rt: ty) (asserted_ty: ty option) (bindings: type_bindings): (type_bindings * ty) =
-  if is_return_type_polymorphic typarams rt then
-    match asserted_ty with
-    | (Some asserted_ty') ->
-       let bindings' = match_type rt asserted_ty' in
-       let bindings'' = merge_bindings bindings bindings' in
-       (bindings'', replace_variables bindings'' rt)
-    | None -> err ("Callable '"
-                   ^ (ident_string name)
-                   ^ "' is polymorphic in the return type but has no asserted type.")
-  else
-    (empty_bindings, replace_variables bindings rt)
+and handle_return_type_polymorphism (name: identifier) (params: value_parameter list) (rt: ty) (asserted_ty: ty option) (bindings: type_bindings): (type_bindings * ty) =
+  let _ = print_endline "---BEGIN---" in
+  print_endline ("Function " ^ (ident_string name));
+  (*print_endline "---BEGIN---";
+  print_endline (ident_string name);
+  print_endline (String.concat ", " (List.map show_type_parameter typarams));
+  print_endline (show_ty rt);
+  print_endline (show_bindings bindings);*)
+  let retval =
+    if is_return_type_polymorphic params rt then
+      let _ = print_endline ("BOOL: is polymorphic on the return type") in
+      match asserted_ty with
+      | (Some asserted_ty') ->
+         let bindings' = match_type rt asserted_ty' in
+         let bindings'' = merge_bindings bindings bindings' in
+         (bindings'', replace_variables bindings'' rt)
+      | None ->
+         err ("Callable '"
+              ^ (ident_string name)
+              ^ "' is polymorphic in the return type but has no asserted type.")
+    else
+      let _ = print_endline ("BOOL: is not polymorphic") in
+      print_endline "Bindings:";
+      print_endline (show_bindings bindings);
+      print_endline ("RT Before:\n" ^ (show_ty rt));
+      print_endline ("RT After:\n" ^ (show_ty (replace_variables bindings rt)));
+      (empty_bindings, replace_variables bindings rt)
+  in
+  print_endline "---END---";
+  retval
 
-(* Given a set of type parameters, check if the return type of a function is polymorphic. *)
-and is_return_type_polymorphic (typarams: type_parameter list) (rt: ty): bool =
-  (* Take the set of type variables in the return type. Remove those that are type parameters. If there are any left, the function is polymorphic in its return type. *)
-  let rt_type_vars = type_variables rt in
-  let vars = TypeVarSet.elements rt_type_vars in
-  let vars_without_parameters =
-    List.filter (fun (TypeVariable (n, _, _)) -> List.exists (fun (TypeParameter (n', _, _)) -> n = n') typarams) vars in
-  List.length vars_without_parameters > 0
+(* Given a function's parameter list and return type, check if the return type
+   of a function is polymorphic. *)
+and is_return_type_polymorphic (params: value_parameter list) (rt: ty): bool =
+  (* Find the set of type variables in the return type. *)
+  let rt_type_vars: TypeVarSet.t = type_variables rt in
+  (* Find the set of type variables in each of the parameters. *)
+  let param_type_vars: TypeVarSet.t list = List.map (fun (ValueParameter (_, ty)) -> type_variables ty) params in
+  (* Union the type variables of the parameters into one set of all type
+     variables in the parameter list. *)
+  let param_type_vars: TypeVarSet.t = List.fold_left TypeVarSet.union TypeVarSet.empty param_type_vars in
+  (* Find the set of type variables that are in the return type set but not in
+     the parameter set. *)
+  let vars_not_params: TypeVarSet.t =
+    let param_ty_vars: type_var list = TypeVarSet.elements param_type_vars
+    in
+    let var_name_in_typarams (n: identifier): bool =
+      List.exists (fun (TypeVariable (n', _, _)) -> equal_identifier n n') param_ty_vars
+    in
+    TypeVarSet.of_list (List.filter (fun (TypeVariable (n, _, _)) -> not (var_name_in_typarams n)) (TypeVarSet.elements rt_type_vars))
+  in
+  (TypeVarSet.cardinal vars_not_params) > 0
 
 (* Check that there are as many bindings as there are type parameters, and that
    every type parameter is satisfied. *)


### PR DESCRIPTION
Fix #162 

There was a truly catastrophic error in `handle_return_type_polymorphism` in the typing pass.