### PR TITLE
Overhaul memory module

### DIFF
--- a/examples/array/Array.aum
+++ b/examples/array/Array.aum
@@ -1,5 +1,5 @@
 import Austral.Memory (
-    Pointer,
+    Address,
     Null_Pointer,
     Allocate,
     Deallocate,
@@ -25,14 +25,14 @@ module body Example.Array is
     end;
 
     function Main(root: Root_Capability): Root_Capability is
-        let arr: Pointer[Boolean] := Allocate(3);
-        let null: Pointer[Boolean] := Null_Pointer();
+        let arr: Address[Boolean] := Allocate(3);
+        let null: Address[Boolean] := Null_Pointer();
         if arr = null then
             skip;
         else
-            let firstp: Pointer[Boolean] := arr;
-            let secondp: Pointer[Boolean] := Positive_Offset(arr, 1);
-            let thirdp: Pointer[Boolean] := Positive_Offset(arr, 2);
+            let firstp: Address[Boolean] := arr;
+            let secondp: Address[Boolean] := Positive_Offset(arr, 1);
+            let thirdp: Address[Boolean] := Positive_Offset(arr, 2);
             Store(firstp, true);
             Store(secondp, false);
             Store(thirdp, true);

--- a/examples/array/Array.aum
+++ b/examples/array/Array.aum
@@ -1,6 +1,7 @@
 import Austral.Memory (
     Address,
-    Null_Pointer,
+    Pointer,
+    Null_Check,
     Allocate,
     Deallocate,
     Positive_Offset,
@@ -25,25 +26,26 @@ module body Example.Array is
     end;
 
     function Main(root: Root_Capability): Root_Capability is
-        let arr: Address[Boolean] := Allocate(3);
-        let null: Address[Boolean] := Null_Pointer();
-        if arr = null then
-            skip;
-        else
-            let firstp: Address[Boolean] := arr;
-            let secondp: Address[Boolean] := Positive_Offset(arr, 1);
-            let thirdp: Address[Boolean] := Positive_Offset(arr, 2);
-            Store(firstp, true);
-            Store(secondp, false);
-            Store(thirdp, true);
-            let first: Boolean := Load(firstp);
-            let second: Boolean := Load(secondp);
-            let third: Boolean := Load(thirdp);
-            Show_Bool(first);
-            Show_Bool(second);
-            Show_Bool(third);
-            Deallocate(arr);
-        end if;
+        let addr: Address[Boolean] := Allocate(3);
+        case Null_Check(addr) of
+            when Some(value: Pointer[Boolean]) do
+                let arr: Pointer[Boolean] := value;
+                let firstp: Pointer[Boolean] := arr;
+                let secondp: Pointer[Boolean] := Positive_Offset(arr, 1);
+                let thirdp: Pointer[Boolean] := Positive_Offset(arr, 2);
+                Store(firstp, true);
+                Store(secondp, false);
+                Store(thirdp, true);
+                let first: Boolean := Load(firstp);
+                let second: Boolean := Load(secondp);
+                let third: Boolean := Load(thirdp);
+                Show_Bool(first);
+                Show_Bool(second);
+                Show_Bool(third);
+                Deallocate(arr);
+            when None do
+                skip;
+        end case;
         return root;
     end;
 end module body.

--- a/examples/box/Box.aum
+++ b/examples/box/Box.aum
@@ -1,6 +1,7 @@
 import Austral.Memory (
     Address,
-    Null_Pointer,
+    Pointer,
+    Null_Check,
     Allocate,
     Load,
     Store,
@@ -13,28 +14,28 @@ module body Example.Box is
     pragma Unsafe_Module;
 
     record Box[T: Type]: Linear is
-        pointer: Address[T];
+        pointer: Pointer[T];
     end;
 
     generic [T: Type]
     function Make(val: T): Either[Box[T], T] is
-        let ptr: Address[T] := Allocate(sizeof(T));
-        let null: Address[T] := Null_Pointer();
-        if ptr = null then
-            -- Allocation failed, return the object we tried to box.
-            let right: Either[Box[T], T] := Right(right => val);
-            return right;
-        else
-            Store(ptr, val);
-            let box: Box[T] := Box(pointer => ptr);
-            let left: Either[Box[T], T] := Left(left => box);
-            return left;
-        end if;
+        let addr: Address[T] := Allocate(sizeof(T));
+        case Null_Check(addr) of
+            when Some(value: Pointer[T]) do
+                Store(value, val);
+                let box: Box[T] := Box(pointer => value);
+                let left: Either[Box[T], T] := Left(left => box);
+                return left;
+            when None do
+                -- Allocation failed, return the object we tried to box.
+                let right: Either[Box[T], T] := Right(right => val);
+                return right;
+        end case;
     end;
 
     generic [T: Type]
     function Unbox(box: Box[T]): T is
-        let { pointer: Address[T] } := box;
+        let { pointer: Pointer[T] } := box;
         let value: T := Load(pointer);
         Deallocate(pointer);
         return value;
@@ -42,7 +43,7 @@ module body Example.Box is
 
     generic [X: Free]
     function Swap_Free(box: Box[X], new: X): Box[X] is
-        let { pointer: Address[X] } := box;
+        let { pointer: Pointer[X] } := box;
         let old: X := Load(pointer);
         Store(pointer, new);
         let newbox: Box[X] := Box(pointer => pointer);
@@ -51,29 +52,29 @@ module body Example.Box is
 
     generic [T: Free, R: Region]
     function Read_Free(boxref: Reference[Box[T], R]): T is
-        let ptrref: Reference[Address[T], R] := boxref->pointer;
-        let ptr: Address[T] := !ptrref;
+        let ptrref: Reference[Pointer[T], R] := boxref->pointer;
+        let ptr: Pointer[T] := !ptrref;
         return Load(ptr);
     end;
 
     generic [T: Free, R: Region]
     function Store_Free(boxref: WriteReference[Box[T], R], value: T): Unit is
-        let ptrref: WriteReference[Address[T], R] := boxref->pointer;
-        let ptr: Address[T] := !(ptrref);
+        let ptrref: WriteReference[Pointer[T], R] := boxref->pointer;
+        let ptr: Pointer[T] := !(ptrref);
         Store(ptr, value);
         return nil;
     end;
 
     generic [T: Type, R: Region]
     function Get_Value_Ref(boxref: Reference[Box[T], R]): Reference[T, R] is
-        let ptrref: Reference[Address[T], R] := boxref->pointer;
+        let ptrref: Reference[Pointer[T], R] := boxref->pointer;
         let ref: Reference[T, R] := Load_Read_Reference(ptrref);
         return ref;
     end;
 
     generic [T: Free, R: Region]
     function Swap_Mut(boxref: WriteReference[Box[T], R], value: T): T is
-        let ptr: Address[T] := !(boxref->pointer);
+        let ptr: Pointer[T] := !(boxref->pointer);
         let old_value: T := Load(ptr);
         Store(ptr, value);
         return old_value;

--- a/examples/box/Box.aum
+++ b/examples/box/Box.aum
@@ -1,5 +1,5 @@
 import Austral.Memory (
-    Pointer,
+    Address,
     Null_Pointer,
     Allocate,
     Load,
@@ -13,13 +13,13 @@ module body Example.Box is
     pragma Unsafe_Module;
 
     record Box[T: Type]: Linear is
-        pointer: Pointer[T];
+        pointer: Address[T];
     end;
 
     generic [T: Type]
     function Make(val: T): Either[Box[T], T] is
-        let ptr: Pointer[T] := Allocate(sizeof(T));
-        let null: Pointer[T] := Null_Pointer();
+        let ptr: Address[T] := Allocate(sizeof(T));
+        let null: Address[T] := Null_Pointer();
         if ptr = null then
             -- Allocation failed, return the object we tried to box.
             let right: Either[Box[T], T] := Right(right => val);
@@ -34,7 +34,7 @@ module body Example.Box is
 
     generic [T: Type]
     function Unbox(box: Box[T]): T is
-        let { pointer: Pointer[T] } := box;
+        let { pointer: Address[T] } := box;
         let value: T := Load(pointer);
         Deallocate(pointer);
         return value;
@@ -42,7 +42,7 @@ module body Example.Box is
 
     generic [X: Free]
     function Swap_Free(box: Box[X], new: X): Box[X] is
-        let { pointer: Pointer[X] } := box;
+        let { pointer: Address[X] } := box;
         let old: X := Load(pointer);
         Store(pointer, new);
         let newbox: Box[X] := Box(pointer => pointer);
@@ -51,29 +51,29 @@ module body Example.Box is
 
     generic [T: Free, R: Region]
     function Read_Free(boxref: Reference[Box[T], R]): T is
-        let ptrref: Reference[Pointer[T], R] := boxref->pointer;
-        let ptr: Pointer[T] := !ptrref;
+        let ptrref: Reference[Address[T], R] := boxref->pointer;
+        let ptr: Address[T] := !ptrref;
         return Load(ptr);
     end;
 
     generic [T: Free, R: Region]
     function Store_Free(boxref: WriteReference[Box[T], R], value: T): Unit is
-        let ptrref: WriteReference[Pointer[T], R] := boxref->pointer;
-        let ptr: Pointer[T] := !(ptrref);
+        let ptrref: WriteReference[Address[T], R] := boxref->pointer;
+        let ptr: Address[T] := !(ptrref);
         Store(ptr, value);
         return nil;
     end;
 
     generic [T: Type, R: Region]
     function Get_Value_Ref(boxref: Reference[Box[T], R]): Reference[T, R] is
-        let ptrref: Reference[Pointer[T], R] := boxref->pointer;
+        let ptrref: Reference[Address[T], R] := boxref->pointer;
         let ref: Reference[T, R] := Load_Read_Reference(ptrref);
         return ref;
     end;
 
     generic [T: Free, R: Region]
     function Swap_Mut(boxref: WriteReference[Box[T], R], value: T): T is
-        let ptr: Pointer[T] := !(boxref->pointer);
+        let ptr: Address[T] := !(boxref->pointer);
         let old_value: T := Load(ptr);
         Store(ptr, value);
         return old_value;

--- a/examples/buffer/Buffer.aum
+++ b/examples/buffer/Buffer.aum
@@ -1,5 +1,5 @@
 import Austral.Memory (
-    Pointer,
+    Address,
     Allocate,
     Resize_Array,
     Deallocate,
@@ -27,9 +27,9 @@ module body Example.Buffer is
 
     -- Allocate an array, and abort if allocation fails.
     generic [T: Type]
-    function Allocate_Or_Die(size: Natural_64): Pointer[T] is
-        let arr: Pointer[T] := Allocate(size);
-        let null: Pointer[T] := Null_Pointer();
+    function Allocate_Or_Die(size: Natural_64): Address[T] is
+        let arr: Address[T] := Allocate(size);
+        let null: Address[T] := Null_Pointer();
         if arr /= null then
             return arr;
         end if;
@@ -47,7 +47,7 @@ module body Example.Buffer is
         -- The number of elements actually stored in the array.
         size: Natural_64;
         -- The underlying heap array.
-        array: Pointer[T];
+        array: Address[T];
 
         -- Invariants:
         --
@@ -72,9 +72,9 @@ module body Example.Buffer is
 
     generic [T: Free]
     function Initialize(size: Natural_64, elem: T): Buffer[T] is
-        let array: Pointer[T] := Allocate_Or_Die(size);
+        let array: Address[T] := Allocate_Or_Die(size);
         for i from 0 to size - 1 do
-            let nth: Pointer[T] := Positive_Offset(array, i);
+            let nth: Address[T] := Positive_Offset(array, i);
             Store(nth, elem);
         end for;
         let buf: Buffer[T] := Buffer(
@@ -87,7 +87,7 @@ module body Example.Buffer is
 
     generic [T: Type]
     function Destroy_Buffer(buffer: Buffer[T]): Unit is
-        let { capacity: Natural_64, size: Natural_64, array: Pointer[T] } := buffer;
+        let { capacity: Natural_64, size: Natural_64, array: Address[T] } := buffer;
         Deallocate(array);
         return nil;
     end;
@@ -103,8 +103,8 @@ module body Example.Buffer is
 
     generic [T: Free, R: Region]
     function Nth_Free(buffer: Reference[Buffer[T], R], index: Natural_64): T is
-        let arr: Pointer[T] := !(buffer->array);
-        let nth_ptr: Pointer[T] := Positive_Offset(arr, index);
+        let arr: Address[T] := !(buffer->array);
+        let nth_ptr: Address[T] := Positive_Offset(arr, index);
         let val: T := Load(nth_ptr);
         return val;
     end;

--- a/examples/buffer/Buffer.aum
+++ b/examples/buffer/Buffer.aum
@@ -1,9 +1,10 @@
 import Austral.Memory (
     Address,
+    Pointer,
     Allocate,
     Resize_Array,
     Deallocate,
-    Null_Pointer,
+    Null_Check,
     Positive_Offset,
     Store,
     Load
@@ -27,12 +28,14 @@ module body Example.Buffer is
 
     -- Allocate an array, and abort if allocation fails.
     generic [T: Type]
-    function Allocate_Or_Die(size: Natural_64): Address[T] is
-        let arr: Address[T] := Allocate(size);
-        let null: Address[T] := Null_Pointer();
-        if arr /= null then
-            return arr;
-        end if;
+    function Allocate_Or_Die(size: Natural_64): Pointer[T] is
+        let addr: Address[T] := Allocate(size);
+        case Null_Check(addr) of
+            when Some(value: Pointer[T]) do
+                return value;
+            when None do
+                Abort("Allocation failed.");
+        end case;
     end;
 
     ---------
@@ -47,7 +50,7 @@ module body Example.Buffer is
         -- The number of elements actually stored in the array.
         size: Natural_64;
         -- The underlying heap array.
-        array: Address[T];
+        array: Pointer[T];
 
         -- Invariants:
         --
@@ -72,9 +75,9 @@ module body Example.Buffer is
 
     generic [T: Free]
     function Initialize(size: Natural_64, elem: T): Buffer[T] is
-        let array: Address[T] := Allocate_Or_Die(size);
+        let array: Pointer[T] := Allocate_Or_Die(size);
         for i from 0 to size - 1 do
-            let nth: Address[T] := Positive_Offset(array, i);
+            let nth: Pointer[T] := Positive_Offset(array, i);
             Store(nth, elem);
         end for;
         let buf: Buffer[T] := Buffer(
@@ -87,7 +90,7 @@ module body Example.Buffer is
 
     generic [T: Type]
     function Destroy_Buffer(buffer: Buffer[T]): Unit is
-        let { capacity: Natural_64, size: Natural_64, array: Address[T] } := buffer;
+        let { capacity: Natural_64, size: Natural_64, array: Pointer[T] } := buffer;
         Deallocate(array);
         return nil;
     end;
@@ -103,8 +106,8 @@ module body Example.Buffer is
 
     generic [T: Free, R: Region]
     function Nth_Free(buffer: Reference[Buffer[T], R], index: Natural_64): T is
-        let arr: Address[T] := !(buffer->array);
-        let nth_ptr: Address[T] := Positive_Offset(arr, index);
+        let arr: Pointer[T] := !(buffer->array);
+        let nth_ptr: Pointer[T] := Positive_Offset(arr, index);
         let val: T := Load(nth_ptr);
         return val;
     end;

--- a/examples/concrete-typeclass/ConcreteTypeclass.aum
+++ b/examples/concrete-typeclass/ConcreteTypeclass.aum
@@ -1,8 +1,4 @@
-import Austral.Memory (Pointer);
-
 module body Example.ConcreteTypeclass is
-    pragma Unsafe_Module;
-
     typeclass Numerical(T: Free) is
         method To_Integer(x: T): Integer_32;
     end;

--- a/examples/concrete-typeclass/ConcreteTypeclass.aum
+++ b/examples/concrete-typeclass/ConcreteTypeclass.aum
@@ -15,6 +15,7 @@ module body Example.ConcreteTypeclass is
     end;
 
     function Main(root: Root_Capability): Root_Capability is
+        Nil_To_Integer();
         return root;
     end;
 end module body.

--- a/examples/generic-typeclass/GenericTypeclass.aum
+++ b/examples/generic-typeclass/GenericTypeclass.aum
@@ -24,6 +24,7 @@ module body Example.GenericTypeclass is
     end;
 
     function Main(root: Root_Capability): Root_Capability is
+        Pointer_To_Integer();
         return root;
     end;
 end module body.

--- a/examples/generic-typeclass/GenericTypeclass.aum
+++ b/examples/generic-typeclass/GenericTypeclass.aum
@@ -1,4 +1,4 @@
-import Austral.Memory (Pointer, Allocate, Null_Pointer);
+import Austral.Memory (Address, Allocate, Null_Pointer);
 
 module body Example.GenericTypeclass is
     pragma Unsafe_Module;
@@ -8,15 +8,15 @@ module body Example.GenericTypeclass is
     end;
 
     generic [T: Free]
-    instance Numerical(Pointer[T]) is
-        method To_Integer(x: Pointer[T]): Integer_32 is
+    instance Numerical(Address[T]) is
+        method To_Integer(x: Address[T]): Integer_32 is
             return 0;
         end;
     end;
 
     function Pointer_To_Integer(): Integer_32 is
-        let ptr: Pointer[Integer_32] := Allocate(sizeof(Integer_32));
-        let null: Pointer[Integer_32] := Null_Pointer();
+        let ptr: Address[Integer_32] := Allocate(sizeof(Integer_32));
+        let null: Address[Integer_32] := Null_Pointer();
         if ptr /= null then
             let X: Integer_32 := To_Integer(ptr);
             return X;

--- a/examples/memory/Memory.aum
+++ b/examples/memory/Memory.aum
@@ -1,5 +1,5 @@
 import Austral.Memory (
-    Pointer,
+    Address,
     Allocate,
     Load,
     Store,
@@ -11,8 +11,8 @@ module body Example.Memory is
     pragma Unsafe_Module;
 
     function Main(root: Root_Capability): Root_Capability is
-        let ptr: Pointer[Integer_32] := Allocate(sizeof(Integer_32));
-        let null: Pointer[Integer_32] := Null_Pointer();
+        let ptr: Address[Integer_32] := Allocate(sizeof(Integer_32));
+        let null: Address[Integer_32] := Null_Pointer();
         if ptr /= null then
             Deallocate(ptr);
         end if;

--- a/examples/memory/Memory.aum
+++ b/examples/memory/Memory.aum
@@ -1,21 +1,25 @@
 import Austral.Memory (
     Address,
+    Pointer,
     Allocate,
     Load,
     Store,
     Deallocate,
-    Null_Pointer
+    Null_Check
 );
 
 module body Example.Memory is
     pragma Unsafe_Module;
 
     function Main(root: Root_Capability): Root_Capability is
-        let ptr: Address[Integer_32] := Allocate(sizeof(Integer_32));
-        let null: Address[Integer_32] := Null_Pointer();
-        if ptr /= null then
-            Deallocate(ptr);
-        end if;
+        let addr: Address[Integer_32] := Allocate(sizeof(Integer_32));
+        case Null_Check(addr) of
+            when Some(value: Pointer[Integer_32]) do
+                Deallocate(value);
+            when None do
+                -- Do nothing.
+                skip;
+        end case;
         return root;
     end;
 end module body.

--- a/examples/pointer-to-record/PTR.aum
+++ b/examples/pointer-to-record/PTR.aum
@@ -1,6 +1,7 @@
 import Austral.Memory (
     Address,
-    Null_Pointer,
+    Pointer,
+    Null_Check,
     Allocate,
     Load,
     Store,
@@ -20,16 +21,16 @@ module body Example.PTR is
 
     function Main(root: Root_Capability): Root_Capability is
         let r: R := R(X => 97);
-        let ptr: Address[R] := Allocate(sizeof(R));
-        let null: Address[R] := Null_Pointer();
-        if ptr = null then
-            -- Do nothing.
-            skip;
-        else
-            Store(ptr, r);
-            Put_Character(ptr->X);
-            Deallocate(ptr);
-        end if;
+        let addr: Address[R] := Allocate(sizeof(R));
+        case Null_Check(addr) of
+            when Some(value: Pointer[R]) do
+                Store(value, r);
+                Put_Character(value->X);
+                Deallocate(value);
+            when None do
+                -- Do nothing.
+                skip;
+        end case;
         return root;
     end;
 end module body.

--- a/examples/pointer-to-record/PTR.aum
+++ b/examples/pointer-to-record/PTR.aum
@@ -1,5 +1,5 @@
 import Austral.Memory (
-    Pointer,
+    Address,
     Null_Pointer,
     Allocate,
     Load,
@@ -20,8 +20,8 @@ module body Example.PTR is
 
     function Main(root: Root_Capability): Root_Capability is
         let r: R := R(X => 97);
-        let ptr: Pointer[R] := Allocate(sizeof(R));
-        let null: Pointer[R] := Null_Pointer();
+        let ptr: Address[R] := Allocate(sizeof(R));
+        let null: Address[R] := Null_Pointer();
         if ptr = null then
             -- Do nothing.
             skip;

--- a/examples/ref-to-record/RTR.aum
+++ b/examples/ref-to-record/RTR.aum
@@ -12,8 +12,8 @@ module body Example.RTR is
     function Main(root: Root_Capability): Root_Capability is
         let r: R := R(X => 97);
         borrow r as r2 in rho do
-            let char: Integer_32 := !(r2->X);
-            Put_Character(char);
+            let c: Integer_32 := !(r2->X);
+            Put_Character(c);
         end;
         let { X: Integer_32 } := r;
         Put_Character(X);

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -68,3 +68,42 @@ and path_elem =
 
 and lvalue =
   LValue of identifier * path_elem list
+
+let expr_kind (expr: aexpr): string =
+  match expr with
+  | NilConstant ->
+     "nil constant"
+  | BoolConstant _ ->
+     "bool constant"
+  | IntConstant _ ->
+     "int constant"
+  | FloatConstant _ ->
+     "float constant"
+  | StringConstant _ ->
+     "string constant"
+  | Variable _ ->
+     "variable"
+  | FunctionCall _ ->
+     "function call"
+  | ArithmeticExpression _ ->
+     "arithmetic"
+  | Comparison _ ->
+     "comparison"
+  | Conjunction _ ->
+     "conjunction"
+  | Disjunction _ ->
+     "disjunction"
+  | Negation _ ->
+     "negation"
+  | IfExpression _ ->
+     "if"
+  | Path _ ->
+     "path"
+  | Embed _ ->
+     "embed"
+  | Deref _ ->
+     "dereference"
+  | Typecast _ ->
+     "typecast"
+  | SizeOf _ ->
+     "sizeof"

--- a/lib/BuiltIn.ml
+++ b/lib/BuiltIn.ml
@@ -40,11 +40,3 @@ let pervasive_imports =
 (* Austral.Memory *)
 
 let memory_module_name = make_mod_name "Austral.Memory"
-
-let pointer_type_name = make_ident "Pointer"
-
-let is_pointer_type (name: qident): bool =
-  let s = source_module_name name
-  and o = original_name name
-  in
-  (equal_module_name s memory_module_name) && (equal_identifier o pointer_type_name)

--- a/lib/BuiltIn.ml
+++ b/lib/BuiltIn.ml
@@ -5,15 +5,13 @@ open Cst
 
 let pervasive_module_name = make_mod_name "Austral.Pervasive"
 
-let option_type_name = make_ident "Option"
-
 let root_cap_type_name = make_ident "Root_Capability"
 
 let pervasive_imports =
   ConcreteImportList (
       pervasive_module_name,
       [
-        ConcreteImport (option_type_name, None);
+        ConcreteImport (make_ident "Option", None);
         ConcreteImport (make_ident "Some", None);
         ConcreteImport (make_ident "None", None);
         ConcreteImport (make_ident "Either", None);

--- a/lib/BuiltIn.mli
+++ b/lib/BuiltIn.mli
@@ -14,5 +14,3 @@ val pervasive_imports: concrete_import_list
 (* Austral.Memory *)
 
 val memory_module_name : module_name
-
-val is_pointer_type : qident -> bool

--- a/lib/BuiltIn.mli
+++ b/lib/BuiltIn.mli
@@ -5,8 +5,6 @@ open Cst
 
 val pervasive_module_name : module_name
 
-val option_type_name : identifier
-
 val root_cap_type_name : identifier
 
 val pervasive_imports: concrete_import_list

--- a/lib/CRenderer.ml
+++ b/lib/CRenderer.ml
@@ -16,7 +16,7 @@ let render_line (Line (Indentation i, s)) =
   (String.make i ' ') ^ s
 
 let desc_text (Desc text): string =
-  "/*\n" ^ text ^ "*/"
+  "/*\n  " ^ text ^ "\n*/"
 
 let rec render_unit (CUnit (name, decls)): string =
   let rd d =

--- a/lib/CRepr.ml
+++ b/lib/CRepr.ml
@@ -65,6 +65,7 @@ type c_decl =
   | CEnumDefinition of string * string list
   | CFunctionDeclaration of string * c_param list * c_ty * c_function_linkage
   | CFunctionDefinition of string * c_param list * c_ty * c_stmt
+  | CDeclComment of string
 
 and c_param = CValueParam of string * c_ty
 

--- a/lib/CRepr.ml
+++ b/lib/CRepr.ml
@@ -56,16 +56,17 @@ type c_stmt =
 and c_switch_case =
   CSwitchCase of c_expr * c_stmt
 
+type desc = Desc of string
+
 type c_decl =
-  | CConstantDefinition of string * c_ty * c_expr
-  | CStructForwardDeclaration of string
-  | CTypeDefinition of string * c_ty
-  | CStructDefinition of c_struct
-  | CNamedStructDefinition of string * c_slot list
-  | CEnumDefinition of string * string list
-  | CFunctionDeclaration of string * c_param list * c_ty * c_function_linkage
-  | CFunctionDefinition of string * c_param list * c_ty * c_stmt
-  | CDeclComment of string
+  | CConstantDefinition of desc * string * c_ty * c_expr
+  | CStructForwardDeclaration of desc * string
+  | CTypeDefinition of desc * string * c_ty
+  | CStructDefinition of desc * c_struct
+  | CNamedStructDefinition of desc * string * c_slot list
+  | CEnumDefinition of desc * string * string list
+  | CFunctionDeclaration of desc * string * c_param list * c_ty * c_function_linkage
+  | CFunctionDefinition of desc * string * c_param list * c_ty * c_stmt
 
 and c_param = CValueParam of string * c_ty
 

--- a/lib/Cli.ml
+++ b/lib/Cli.ml
@@ -2,6 +2,7 @@ open Identifier
 open Compiler
 open Util
 open Error
+open Reporter
 
 (* Map of filenames to file contents. *)
 module SourceMap =
@@ -85,7 +86,13 @@ let dump_and_die _: unit =
   Reporter.dump ();
   exit (-1)
 
-let compile_main (args: string list): unit =
+let rec compile_main (args: string list): unit =
+  with_frame "Entrypoint"
+    (fun () ->
+      ps ("Arguments: ", String.concat " " args);
+      compile_main' args)
+
+and compile_main' (args: string list): unit =
   let (contents, source_map) = parse_source_files args in
   try
     let args' = List.map parse_arg args in

--- a/lib/Cli.ml
+++ b/lib/Cli.ml
@@ -157,6 +157,7 @@ let main (args: string list): unit =
   try
     Printexc.record_backtrace true;
     main' args;
+    Reporter.dump ();
     exit 0
   with Austral_error error ->
     Printf.eprintf "%s" (render_error error None);

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -124,7 +124,7 @@ let rec gen_type (ty: mono_ty): c_ty =
      CPointer (gen_type t)
   | MonoWriteRef (t, _) ->
      CPointer (gen_type t)
-  | MonoRawPointer t ->
+  | MonoAddress t ->
      CPointer (gen_type t)
   | MonoRegionTyVar _ ->
      err "internal"
@@ -288,7 +288,7 @@ let rec gen_stmt (mn: module_name) (stmt: mstmt): c_stmt =
   | MBorrow { original; rename; orig_type; body; _ } ->
      let is_pointer =
        (match orig_type with
-        | MonoRawPointer _ ->
+        | MonoAddress _ ->
            true
         | _ ->
            false)
@@ -448,7 +448,7 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
              c_string_type
            else
              err "Not allowed"
-        | MonoRawPointer _ ->
+        | MonoAddress _ ->
            gen_type t
         | MonoNamedType _ ->
            err "Not implemented"

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -374,12 +374,12 @@ let get_original_module_name (env: env) (id: mono_id): module_name =
 let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
   match decl with
   | MConstant (_, n, ty, e) ->
-     let d = Desc "" in
+     let d = Desc "Constant" in
      [
        CConstantDefinition (d, gen_sident mn n, gen_type ty, gen_exp mn e)
      ]
   | MTypeAlias (_, n, ty) ->
-     let d = Desc "" in
+     let d = Desc "Type Alias" in
      [
        CStructDefinition (
            d,
@@ -392,7 +392,7 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
          )
      ]
   | MTypeAliasMonomorph (id, ty) ->
-     let d = Desc "" in
+     let d = Desc "Type alias monomorph" in
      [
        CNamedStructDefinition (
            d,
@@ -403,18 +403,18 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
          )
      ]
   | MRecord (id, _, slots) ->
-     let d = Desc "" in
+     let d = Desc "Record" in
      [
        CNamedStructDefinition (d, gen_decl_id id, gen_slots slots)
      ]
   | MRecordMonomorph (id, slots) ->
-     let d = Desc "" in
+     let d = Desc "Record monomorph" in
      [
        CNamedStructDefinition (d, gen_mono_id id, gen_slots slots)
      ]
   | MUnion (_, n, cases) ->
-     let enum_d = Desc "" in
-     let union_d = Desc "" in
+     let enum_d = Desc "Union tag enum" in
+     let union_d = Desc "Union" in
      let enum_def = CEnumDefinition (
                         enum_d,
                         (gen_ident n) ^ "_tag",
@@ -431,8 +431,8 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
      in
      [enum_def; union_def]
   | MUnionMonomorph (id, cases) ->
-     let enum_d = Desc "" in
-     let union_d = Desc "" in
+     let enum_d = Desc "Union monomorph tag enum" in
+     let union_d = Desc "Union monomorph" in
      let enum_def = CEnumDefinition (
                         enum_d,
                         local_union_tag_enum_name_from_id id,
@@ -449,7 +449,7 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
      in
      [enum_def; union_def]
   | MFunction (id, _, params, rt, body) ->
-     let d = Desc "" in
+     let d = Desc "Function" in
      [
        CFunctionDefinition (d, gen_decl_id id, gen_params mn params, gen_type rt, gen_stmt mn body)
      ]
@@ -457,13 +457,13 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
      (* Load-bearing hack: prefix parameters not with the current module name,
         but with the name of the module the monomorph's declaration is from. *)
      let mn': module_name = get_original_module_name env id in
-     let d = Desc "" in
+     let d = Desc "Function monomorph" in
      [
        CFunctionDefinition (d, gen_mono_id id, gen_params mn' params, gen_type rt, gen_stmt mn body)
      ]
   | MForeignFunction (id, _, params, rt, underlying) ->
-     let decl_d = Desc "" in
-     let def_d = Desc "" in
+     let decl_d = Desc "Foreign function decl" in
+     let def_d = Desc "Foreign function" in
      let param_type_to_c_type (t: mono_ty): c_ty =
        (match t with
         | MonoUnit ->
@@ -513,7 +513,7 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
   | MConcreteInstance (_, _, _, methods) ->
      List.map (gen_method mn) methods
   | MMethodMonomorph (id, params, rt, body) ->
-     let d = Desc "" in
+     let d = Desc "Method monomorph" in
      [
        CFunctionDefinition (d, gen_mono_id id, gen_params mn params, gen_type rt, gen_stmt mn body)
      ]
@@ -541,24 +541,24 @@ let rec gen_fun_decls mn decls =
 and gen_fun_decl mn decl =
   match decl with
   | MFunction (id, _, p, rt, _) ->
-     let d = Desc "" in
+     let d = Desc "Function forward declaratioon" in
      Some [CFunctionDeclaration (d, gen_decl_id id, gen_params mn p, gen_type rt, LinkageInternal)]
   | MFunctionMonomorph (id, p, rt, _) ->
-     let d = Desc "" in
+     let d = Desc "Function monomorph forward declaration" in
      Some [CFunctionDeclaration (d, gen_mono_id id, gen_params mn p, gen_type rt, LinkageInternal)]
   | MForeignFunction (id, _, p, rt, _) ->
-     let d = Desc "" in
+     let d = Desc "Foreign function forward declaration" in
      Some [CFunctionDeclaration (d, gen_decl_id id, gen_params mn p, gen_type rt, LinkageInternal)]
   | MConcreteInstance (_, _, _, ms) ->
      Some (List.map (gen_method_decl mn) ms)
   | MMethodMonomorph (id, p, rt, _) ->
-     let d = Desc "" in
+     let d = Desc "Method monomorph forward declaration" in
      Some [CFunctionDeclaration (d, gen_mono_id id, gen_params mn p, gen_type rt, LinkageInternal)]
   | _ ->
      None
 
 and gen_method_decl mn (MConcreteMethod (id, _, params, rt, _)) =
-  let d = Desc "" in
+  let d = Desc "Method forward declaration" in
   CFunctionDeclaration (d, gen_ins_meth_id id, gen_params mn params, gen_type rt, LinkageInternal)
 
 (* Codegen a module *)

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -126,6 +126,8 @@ let rec gen_type (ty: mono_ty): c_ty =
      CPointer (gen_type t)
   | MonoAddress t ->
      CPointer (gen_type t)
+  | MonoPointer t ->
+     CPointer (gen_type t)
   | MonoRegionTyVar _ ->
      err "internal"
 

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -177,8 +177,12 @@ let rec gen_exp (mn: module_name) (e: mexpr): c_expr =
            CInt (string_of_int (String.length (escaped_to_string s)))
          ]
        )
-  | MVariable (n, _) ->
+  | MConstVar (n, _) ->
      CVar (gen_qident n)
+  | MParamVar (n, _) ->
+     CVar (gen_ident n)
+  | MLocalVar (n, _) ->
+     CVar (gen_ident n)
   | MConcreteFuncall (id, _, args, _) ->
      CFuncall (gen_decl_id id, List.map g args)
   | MGenericFuncall (id, args, _) ->

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -373,7 +373,9 @@ let get_original_module_name (env: env) (id: mono_id): module_name =
 let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
   match decl with
   | MConstant (_, n, ty, e) ->
-     [CConstantDefinition (gen_sident mn n, gen_type ty, gen_exp mn e)]
+     [
+       CConstantDefinition (gen_sident mn n, gen_type ty, gen_exp mn e)
+     ]
   | MTypeAlias (_, n, ty) ->
      [
        CStructDefinition (
@@ -431,12 +433,16 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
      in
      [enum_def; union_def]
   | MFunction (id, _, params, rt, body) ->
-     [CFunctionDefinition (gen_decl_id id, gen_params mn params, gen_type rt, gen_stmt mn body)]
+     [
+       CFunctionDefinition (gen_decl_id id, gen_params mn params, gen_type rt, gen_stmt mn body)
+     ]
   | MFunctionMonomorph (id, params, rt, body) ->
      (* Load-bearing hack: prefix parameters not with the current module name,
         but with the name of the module the monomorph's declaration is from. *)
      let mn': module_name = get_original_module_name env id in
-     [CFunctionDefinition (gen_mono_id id, gen_params mn' params, gen_type rt, gen_stmt mn body)]
+     [
+       CFunctionDefinition (gen_mono_id id, gen_params mn' params, gen_type rt, gen_stmt mn body)
+     ]
   | MForeignFunction (id, _, params, rt, underlying) ->
      let param_type_to_c_type (t: mono_ty): c_ty =
        (match t with
@@ -487,7 +493,9 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
   | MConcreteInstance (_, _, _, methods) ->
      List.map (gen_method mn) methods
   | MMethodMonomorph (id, params, rt, body) ->
-     [CFunctionDefinition (gen_mono_id id, gen_params mn params, gen_type rt, gen_stmt mn body)]
+     [
+       CFunctionDefinition (gen_mono_id id, gen_params mn params, gen_type rt, gen_stmt mn body)
+     ]
 
 (* Extract types into forward type declarations *)
 

--- a/lib/CombiningPass.ml
+++ b/lib/CombiningPass.ml
@@ -230,7 +230,7 @@ and parse_decl (module_name: module_name) (im: import_map) (bm: import_map) (cmb
   let make_qname n =
     make_qident (module_name, n, n)
   in
-  match decl_name decl with
+  match concrete_decl_name decl with
   | (Some name) ->
      (match decl with
       (* Some declarations don't need to have a matching body *)

--- a/lib/Cst.ml
+++ b/lib/Cst.ml
@@ -146,7 +146,7 @@ let make_module_body (name: module_name) (imports: concrete_import_list list) (p
   in
   ConcreteModuleBody (name, kind, docstring, imports, defs)
 
-let decl_name = function
+let concrete_decl_name = function
   | ConcreteConstantDecl (n, _, _) -> Some n
   | ConcreteOpaqueTypeDecl (n, _, _, _) -> Some n
   | ConcreteTypeAliasDecl (ConcreteTypeAlias (n, _, _, _, _)) -> Some n
@@ -167,7 +167,7 @@ let def_name = function
 
 let get_concrete_decl (ConcreteModuleInterface (_, _, _, decls)) name =
   let pred decl =
-    match decl_name decl with
+    match concrete_decl_name decl with
     | (Some name') ->
        name = name'
     | None ->

--- a/lib/Cst.mli
+++ b/lib/Cst.mli
@@ -132,7 +132,7 @@ and concrete_lvalue =
 (** Used by the parser to easily create a module body from its components and a list of pragmas. *)
 val make_module_body : module_name -> concrete_import_list list -> pragma list -> concrete_def list -> docstring -> concrete_module_body
 
-val decl_name : concrete_decl -> identifier option
+val concrete_decl_name : concrete_decl -> identifier option
 
 val def_name : concrete_def -> identifier option
 

--- a/lib/Env.ml
+++ b/lib/Env.ml
@@ -611,16 +611,16 @@ let get_callable (env: env) (importing_module_name: module_name) (name: sident):
   | None ->
      None
 
-let get_variable (env: env) (lexenv: lexenv) (name: qident): ty option =
+let get_variable (env: env) (lexenv: lexenv) (name: qident): (ty * var_source) option =
   match get_var lexenv (original_name name) with
-  | Some ty ->
-     Some ty
+  | Some (ty, src) ->
+     Some (ty, src)
   | None ->
      (match get_decl_by_name env (qident_to_sident name) with
       | Some decl ->
          (match decl with
           | Constant { ty; _ } ->
-             Some ty
+             Some (ty, VarConstant)
           | _ ->
              None)
       | None ->

--- a/lib/Env.mli
+++ b/lib/Env.mli
@@ -430,7 +430,7 @@ val get_callable : env -> module_name -> sident -> callable option
 
 (** Get the type of a variable, trying first the lexenv and then the env for
     constants. *)
-val get_variable : env -> lexenv -> qident -> ty option
+val get_variable : env -> lexenv -> qident -> (ty * var_source) option
 
 (** Return all typeclass instances visible from a module. These are not only the
     instances that are defined in the module itself, but the instances imported

--- a/lib/Env.mli
+++ b/lib/Env.mli
@@ -466,6 +466,9 @@ val get_monomorph : env -> mono_id -> monomorph option
 (** Return the ID of a declaration. *)
 val decl_id : decl -> decl_id
 
+(** Return the name of a declaration. *)
+val decl_name : decl -> identifier option
+
 (** Return whether a declaration is importable by a foreign module. *)
 val is_importable: decl -> bool
 

--- a/lib/Identifier.ml
+++ b/lib/Identifier.ml
@@ -33,11 +33,14 @@ let original_name { original; _ } = original
 let local_name { local; _ } = local
 
 let qident_debug_name { source; original; local } =
-  let s = mod_name_string source
+  let mn = mod_name_string source
   and o = ident_string original
   and l = ident_string local
   in
-  l ^ " from " ^ s ^ (if o = l then "" else (", originally " ^ o))
+  if o = l then
+    mn ^ "::" ^ o
+  else
+    mn ^ "::" ^ o ^ "(" ^ "local=" ^ l ^ ")"
 
 let equal_qident { source; original; _ } { source=source'; original=original'; _ } =
   (equal_module_name source source') && (equal_identifier original original')

--- a/lib/LexEnv.ml
+++ b/lib/LexEnv.ml
@@ -2,25 +2,30 @@ open Identifier
 open Type
 open Error
 
-type lexenv = (identifier * ty) list
+type var_source =
+  | VarConstant
+  | VarParam
+  | VarLocal
+
+type lexenv = (identifier * ty * var_source) list
 
 let empty_lexenv =
   []
 
-let get_var l name =
-  Option.map (fun (_, t) -> t) (List.find_opt (fun (n, _) -> n = name) l)
+let get_var (l: lexenv) (name: identifier): (ty * var_source) option =
+  Option.map (fun (_, t, s) -> (t, s)) (List.find_opt (fun (n, _, _) -> n = name) l)
 
-let push_var l name ty =
+let push_var l name ty source =
   match get_var l name with
   | (Some _) ->
      err "push_var: var with this name already exists"
   | None ->
-     (name, ty) :: l
+     (name, ty, source) :: l
 
 let rec push_vars env l =
   match l with
-  | (n,t)::rest ->
-     push_vars (push_var env n t) rest
+  | (n,t,s)::rest ->
+     push_vars (push_var env n t s) rest
   | [] ->
      env
 

--- a/lib/LexEnv.mli
+++ b/lib/LexEnv.mli
@@ -1,14 +1,20 @@
+(** Stores the lexical environment. *)
 open Identifier
 open Type
 
 type lexenv
 
+type var_source =
+  | VarConstant
+  | VarParam
+  | VarLocal
+
 val empty_lexenv : lexenv
 
-val push_var : lexenv -> identifier -> ty -> lexenv
+val push_var : lexenv -> identifier -> ty -> var_source -> lexenv
 
-val push_vars : lexenv -> (identifier * ty) list -> lexenv
+val push_vars : lexenv -> (identifier * ty * var_source) list -> lexenv
 
 val pop_var : lexenv -> lexenv
 
-val get_var : lexenv -> identifier -> ty option
+val get_var : lexenv -> identifier -> (ty * var_source) option

--- a/lib/Linearity.ml
+++ b/lib/Linearity.ml
@@ -30,9 +30,16 @@ let rec count_appearances (name: identifier) (expr: texpr) =
      0
   | TStringConstant _ ->
      0
-  | TVariable (n, _) ->
-     (* TODO: is using original_name here correct? *)
-     if equal_identifier name (original_name n) then
+  | TConstVar _ ->
+     (* Constants are never linear, don't worry about it. *)
+     0
+  | TParamVar (n, _) ->
+     if equal_identifier name n then
+       1
+     else
+       0
+  | TLocalVar (n, _) ->
+     if equal_identifier name n then
        1
      else
        0
@@ -75,7 +82,11 @@ let rec count_appearances (name: identifier) (expr: texpr) =
           unless the expression is just a bare variable. So `f(x).y` will count
           but not `x.y`. *)
        (match head with
-        | TVariable _ ->
+        | TConstVar _ ->
+           0
+        | TParamVar _ ->
+           0
+        | TLocalVar _ ->
            0
         | _ ->
            ca head)

--- a/lib/MemoryModule.ml
+++ b/lib/MemoryModule.ml
@@ -63,8 +63,8 @@ module body Austral.Memory is
 
     generic [T: Type]
     function Null_Check(address: Address[T]): Option[Pointer[T]] is
-        let null: Address[T] := Null_Pointer();
-        if address /= null then
+        let n: Address[T] := Null_Pointer();
+        if address /= n then
             let ptr: Pointer[T] := @embed(Pointer[T], "$1", address);
             return Some(value => ptr);
         else

--- a/lib/MemoryModule.ml
+++ b/lib/MemoryModule.ml
@@ -5,9 +5,13 @@ let memory_interface_source = {code|
 
 module Austral.Memory is
     type Address[T: Type]: Free;
+    type Pointer[T: Type]: Free;
 
     generic [T: Type]
     function Null_Pointer(): Address[T];
+
+    generic [T: Type]
+    function Null_Check(address: Address[T]): Option[Pointer[T]];
 
     generic [T: Type]
     function Allocate(size: Natural_64): Address[T];
@@ -50,10 +54,22 @@ let memory_body_source = {code|
 
 module body Austral.Memory is
     type Address[T: Type]: Free is Unit;
+    type Pointer[T: Type]: Free is Unit;
 
     generic [T: Type]
     function Null_Pointer(): Address[T] is
         return @embed(Address[T], "NULL");
+    end;
+
+    generic [T: Type]
+    function Null_Check(address: Address[T]): Option[Pointer[T]] is
+        let n: Address[T] := Null_Pointer();
+        if address /= null then
+            let ptr: Pointer[T] := @embed(Pointer[T], "$1", address);
+            return Some(ptr);
+        else
+            return None();
+        end if;
     end;
 
     generic [T: Type]

--- a/lib/MemoryModule.ml
+++ b/lib/MemoryModule.ml
@@ -4,43 +4,43 @@
 let memory_interface_source = {code|
 
 module Austral.Memory is
-    type Pointer[T: Type]: Free;
+    type Address[T: Type]: Free;
 
     generic [T: Type]
-    function Null_Pointer(): Pointer[T];
+    function Null_Pointer(): Address[T];
 
     generic [T: Type]
-    function Allocate(size: Natural_64): Pointer[T];
+    function Allocate(size: Natural_64): Address[T];
 
     generic [T: Type]
-    function Load(pointer: Pointer[T]): T;
+    function Load(address: Address[T]): T;
 
     generic [T: Type]
-    function Store(pointer: Pointer[T], value: T): Unit;
+    function Store(address: Address[T], value: T): Unit;
 
     generic [T: Type]
-    function Deallocate(pointer: Pointer[T]): Unit;
+    function Deallocate(address: Address[T]): Unit;
 
     generic [T: Type, R: Region]
-    function Load_Read_Reference(ref: Reference[Pointer[T], R]): Reference[T, R];
+    function Load_Read_Reference(ref: Reference[Address[T], R]): Reference[T, R];
 
     generic [T: Type, R: Region]
-    function Load_Write_Reference(ref: WriteReference[Pointer[T], R]): WriteReference[T, R];
+    function Load_Write_Reference(ref: WriteReference[Address[T], R]): WriteReference[T, R];
 
     generic [T: Type]
-    function Resize_Array(array: Pointer[T], size: Natural_64): Pointer[T];
+    function Resize_Array(array: Address[T], size: Natural_64): Address[T];
 
     generic [T: Type, U: Type]
-    function memmove(source: Pointer[T], destination: Pointer[U], count: Natural_64): Unit;
+    function memmove(source: Address[T], destination: Address[U], count: Natural_64): Unit;
 
     generic [T: Type, U: Type]
-    function memcpy(source: Pointer[T], destination: Pointer[U], count: Natural_64): Unit;
+    function memcpy(source: Address[T], destination: Address[U], count: Natural_64): Unit;
 
     generic [T: Type]
-    function Positive_Offset(pointer: Pointer[T], offset: Natural_64): Pointer[T];
+    function Positive_Offset(pointer: Address[T], offset: Natural_64): Address[T];
 
     generic [T: Type]
-    function Negative_Offset(pointer: Pointer[T], offset: Natural_64): Pointer[T];
+    function Negative_Offset(pointer: Address[T], offset: Natural_64): Address[T];
 end module.
 
 |code}
@@ -49,71 +49,71 @@ end module.
 let memory_body_source = {code|
 
 module body Austral.Memory is
-    type Pointer[T: Type]: Free is Unit;
+    type Address[T: Type]: Free is Unit;
 
     generic [T: Type]
-    function Null_Pointer(): Pointer[T] is
-        return @embed(Pointer[T], "NULL");
+    function Null_Pointer(): Address[T] is
+        return @embed(Address[T], "NULL");
     end;
 
     generic [T: Type]
-    function Load(pointer: Pointer[T]): T is
-        return @embed(T, "*($1)", pointer);
+    function Load(address: Address[T]): T is
+        return @embed(T, "*($1)", address);
     end;
 
     generic [T: Type]
-    function Store(pointer: Pointer[T], value: T): Unit is
-        @embed(Unit, "AU_STORE($1, $2)", pointer, value);
+    function Store(address: Address[T], value: T): Unit is
+        @embed(Unit, "AU_STORE($1, $2)", address, value);
         return nil;
     end;
 
     generic [T: Type]
-    function Deallocate(pointer: Pointer[T]): Unit is
-        @embed(Unit, "au_free($1)", pointer);
+    function Deallocate(address: Address[T]): Unit is
+        @embed(Unit, "au_free($1)", address);
         return nil;
     end;
 
     generic [T: Type, R: Region]
-    function Load_Read_Reference(ref: Reference[Pointer[T], R]): Reference[T, R] is
+    function Load_Read_Reference(ref: Reference[Address[T], R]): Reference[T, R] is
         return @embed(Reference[T, R], "*($1)", ref);
     end;
 
     generic [T: Type, R: Region]
-    function Load_Write_Reference(ref: WriteReference[Pointer[T], R]): WriteReference[T, R] is
+    function Load_Write_Reference(ref: WriteReference[Address[T], R]): WriteReference[T, R] is
         return @embed(WriteReference[T, R], "*($1)", ref);
     end;
 
     generic [T: Type]
-    function Allocate(size: Natural_64): Pointer[T] is
-        return @embed(Pointer[T], "au_calloc($1, $2)", sizeof(T), size);
+    function Allocate(size: Natural_64): Address[T] is
+        return @embed(Address[T], "au_calloc($1, $2)", sizeof(T), size);
     end;
 
     generic [T: Type]
-    function Resize_Array(array: Pointer[T], size: Natural_64): Pointer[T] is
+    function Resize_Array(array: Address[T], size: Natural_64): Address[T] is
         let total: Natural_64 := (sizeof(T)) * size;
-        return @embed(Pointer[T], "au_realloc($1, $2)", array, total);
+        return @embed(Address[T], "au_realloc($1, $2)", array, total);
     end;
 
     generic [T: Type, U: Type]
-    function memmove(source: Pointer[T], destination: Pointer[U], count: Natural_64): Unit is
-        @embed(Pointer[T], "au_memmove($1, $2, $3)", destination, source, count);
+    function memmove(source: Address[T], destination: Address[U], count: Natural_64): Unit is
+        @embed(Address[T], "au_memmove($1, $2, $3)", destination, source, count);
         return nil;
     end;
 
     generic [T: Type, U: Type]
-    function memcpy(source: Pointer[T], destination: Pointer[U], count: Natural_64): Unit is
-        @embed(Pointer[T], "au_memcpy($1, $2, $3)", destination, source, count);
+    function memcpy(source: Address[T], destination: Address[U], count: Natural_64): Unit is
+        @embed(Address[T], "au_memcpy($1, $2, $3)", destination, source, count);
         return nil;
     end;
 
     generic [T: Type]
-    function Positive_Offset(pointer: Pointer[T], offset: Natural_64): Pointer[T] is
-        return @embed(Pointer[T], "$1 + $2", pointer, offset);
+    function Positive_Offset(pointer: Address[T], offset: Natural_64): Address[T] is
+        return @embed(Address[T], "$1 + $2", pointer, offset);
     end;
 
     generic [T: Type]
-    function Negative_Offset(pointer: Pointer[T], offset: Natural_64): Pointer[T] is
-        return @embed(Pointer[T], "$1 - $2", pointer, offset);
+    function Negative_Offset(pointer: Address[T], offset: Natural_64): Address[T] is
+        return @embed(Address[T], "$1 - $2", pointer, offset);
     end;
 end module body.
 

--- a/lib/MemoryModule.ml
+++ b/lib/MemoryModule.ml
@@ -63,12 +63,13 @@ module body Austral.Memory is
 
     generic [T: Type]
     function Null_Check(address: Address[T]): Option[Pointer[T]] is
-        let n: Address[T] := Null_Pointer();
+        let null: Address[T] := Null_Pointer();
         if address /= null then
             let ptr: Pointer[T] := @embed(Pointer[T], "$1", address);
-            return Some(ptr);
+            return Some(value => ptr);
         else
-            return None();
+            let res: Option[Pointer[T]] := None();
+            return res;
         end if;
     end;
 

--- a/lib/MemoryModule.ml
+++ b/lib/MemoryModule.ml
@@ -17,34 +17,34 @@ module Austral.Memory is
     function Allocate(size: Natural_64): Address[T];
 
     generic [T: Type]
-    function Load(address: Address[T]): T;
+    function Load(pointer: Pointer[T]): T;
 
     generic [T: Type]
-    function Store(address: Address[T], value: T): Unit;
+    function Store(pointer: Pointer[T], value: T): Unit;
 
     generic [T: Type]
-    function Deallocate(address: Address[T]): Unit;
+    function Deallocate(pointer: Pointer[T]): Unit;
 
     generic [T: Type, R: Region]
-    function Load_Read_Reference(ref: Reference[Address[T], R]): Reference[T, R];
+    function Load_Read_Reference(ref: Reference[Pointer[T], R]): Reference[T, R];
 
     generic [T: Type, R: Region]
-    function Load_Write_Reference(ref: WriteReference[Address[T], R]): WriteReference[T, R];
+    function Load_Write_Reference(ref: WriteReference[Pointer[T], R]): WriteReference[T, R];
 
     generic [T: Type]
-    function Resize_Array(array: Address[T], size: Natural_64): Address[T];
+    function Resize_Array(array: Pointer[T], size: Natural_64): Pointer[T];
 
     generic [T: Type, U: Type]
-    function memmove(source: Address[T], destination: Address[U], count: Natural_64): Unit;
+    function memmove(source: Pointer[T], destination: Pointer[U], count: Natural_64): Unit;
 
     generic [T: Type, U: Type]
-    function memcpy(source: Address[T], destination: Address[U], count: Natural_64): Unit;
+    function memcpy(source: Pointer[T], destination: Pointer[U], count: Natural_64): Unit;
 
     generic [T: Type]
-    function Positive_Offset(pointer: Address[T], offset: Natural_64): Address[T];
+    function Positive_Offset(pointer: Pointer[T], offset: Natural_64): Pointer[T];
 
     generic [T: Type]
-    function Negative_Offset(pointer: Address[T], offset: Natural_64): Address[T];
+    function Negative_Offset(pointer: Pointer[T], offset: Natural_64): Pointer[T];
 end module.
 
 |code}
@@ -74,63 +74,63 @@ module body Austral.Memory is
     end;
 
     generic [T: Type]
-    function Load(address: Address[T]): T is
-        return @embed(T, "*($1)", address);
-    end;
-
-    generic [T: Type]
-    function Store(address: Address[T], value: T): Unit is
-        @embed(Unit, "AU_STORE($1, $2)", address, value);
-        return nil;
-    end;
-
-    generic [T: Type]
-    function Deallocate(address: Address[T]): Unit is
-        @embed(Unit, "au_free($1)", address);
-        return nil;
-    end;
-
-    generic [T: Type, R: Region]
-    function Load_Read_Reference(ref: Reference[Address[T], R]): Reference[T, R] is
-        return @embed(Reference[T, R], "*($1)", ref);
-    end;
-
-    generic [T: Type, R: Region]
-    function Load_Write_Reference(ref: WriteReference[Address[T], R]): WriteReference[T, R] is
-        return @embed(WriteReference[T, R], "*($1)", ref);
-    end;
-
-    generic [T: Type]
     function Allocate(size: Natural_64): Address[T] is
         return @embed(Address[T], "au_calloc($1, $2)", sizeof(T), size);
     end;
 
     generic [T: Type]
-    function Resize_Array(array: Address[T], size: Natural_64): Address[T] is
+    function Load(pointer: Pointer[T]): T is
+        return @embed(T, "*($1)", pointer);
+    end;
+
+    generic [T: Type]
+    function Store(pointer: Pointer[T], value: T): Unit is
+        @embed(Unit, "AU_STORE($1, $2)", pointer, value);
+        return nil;
+    end;
+
+    generic [T: Type]
+    function Deallocate(pointer: Pointer[T]): Unit is
+        @embed(Unit, "au_free($1)", pointer);
+        return nil;
+    end;
+
+    generic [T: Type, R: Region]
+    function Load_Read_Reference(ref: Reference[Pointer[T], R]): Reference[T, R] is
+        return @embed(Reference[T, R], "*($1)", ref);
+    end;
+
+    generic [T: Type, R: Region]
+    function Load_Write_Reference(ref: WriteReference[Pointer[T], R]): WriteReference[T, R] is
+        return @embed(WriteReference[T, R], "*($1)", ref);
+    end;
+
+    generic [T: Type]
+    function Resize_Array(array: Pointer[T], size: Natural_64): Pointer[T] is
         let total: Natural_64 := (sizeof(T)) * size;
-        return @embed(Address[T], "au_realloc($1, $2)", array, total);
+        return @embed(Pointer[T], "au_realloc($1, $2)", array, total);
     end;
 
     generic [T: Type, U: Type]
-    function memmove(source: Address[T], destination: Address[U], count: Natural_64): Unit is
-        @embed(Address[T], "au_memmove($1, $2, $3)", destination, source, count);
+    function memmove(source: Pointer[T], destination: Pointer[U], count: Natural_64): Unit is
+        @embed(Pointer[T], "au_memmove($1, $2, $3)", destination, source, count);
         return nil;
     end;
 
     generic [T: Type, U: Type]
-    function memcpy(source: Address[T], destination: Address[U], count: Natural_64): Unit is
-        @embed(Address[T], "au_memcpy($1, $2, $3)", destination, source, count);
+    function memcpy(source: Pointer[T], destination: Pointer[U], count: Natural_64): Unit is
+        @embed(Pointer[T], "au_memcpy($1, $2, $3)", destination, source, count);
         return nil;
     end;
 
     generic [T: Type]
-    function Positive_Offset(pointer: Address[T], offset: Natural_64): Address[T] is
-        return @embed(Address[T], "$1 + $2", pointer, offset);
+    function Positive_Offset(pointer: Pointer[T], offset: Natural_64): Pointer[T] is
+        return @embed(Pointer[T], "$1 + $2", pointer, offset);
     end;
 
     generic [T: Type]
-    function Negative_Offset(pointer: Address[T], offset: Natural_64): Address[T] is
-        return @embed(Address[T], "$1 - $2", pointer, offset);
+    function Negative_Offset(pointer: Pointer[T], offset: Natural_64): Pointer[T] is
+        return @embed(Pointer[T], "$1 - $2", pointer, offset);
     end;
 end module body.
 

--- a/lib/MemoryModule.ml
+++ b/lib/MemoryModule.ml
@@ -66,7 +66,8 @@ module body Austral.Memory is
         let n: Address[T] := Null_Pointer();
         if address /= n then
             let ptr: Pointer[T] := @embed(Pointer[T], "$1", address);
-            return Some(value => ptr);
+            let opt: Option[Pointer[T]] := Some(value => ptr);
+            return opt;
         else
             let res: Option[Pointer[T]] := None();
             return res;

--- a/lib/MonoType.ml
+++ b/lib/MonoType.ml
@@ -16,7 +16,7 @@ type mono_ty =
   | MonoRegionTy of region
   | MonoReadRef of mono_ty * mono_ty
   | MonoWriteRef of mono_ty * mono_ty
-  | MonoRawPointer of mono_ty
+  | MonoAddress of mono_ty
   | MonoRegionTyVar of identifier * qident
 [@@deriving (eq, show)]
 

--- a/lib/MonoType.ml
+++ b/lib/MonoType.ml
@@ -17,6 +17,7 @@ type mono_ty =
   | MonoReadRef of mono_ty * mono_ty
   | MonoWriteRef of mono_ty * mono_ty
   | MonoAddress of mono_ty
+  | MonoPointer of mono_ty
   | MonoRegionTyVar of identifier * qident
 [@@deriving (eq, show)]
 

--- a/lib/Monomorphize.ml
+++ b/lib/Monomorphize.ml
@@ -98,9 +98,15 @@ let rec monomorphize_expr (env: env) (expr: texpr): (mexpr * env) =
      (MFloatConstant f, env)
   | TStringConstant s ->
      (MStringConstant s, env)
-  | TVariable (name, ty) ->
+  | TConstVar (name, ty) ->
      let (ty, env) = strip_and_mono env ty in
-     (MVariable (name, ty), env)
+     (MConstVar (name, ty), env)
+  | TParamVar (name, ty) ->
+     let (ty, env) = strip_and_mono env ty in
+     (MParamVar (name, ty), env)
+  | TLocalVar (name, ty) ->
+     let (ty, env) = strip_and_mono env ty in
+     (MLocalVar (name, ty), env)
   | TArithmetic (oper, lhs, rhs) ->
      let (lhs, env) = monomorphize_expr env lhs in
      let (rhs, env) = monomorphize_expr env rhs in

--- a/lib/Monomorphize.ml
+++ b/lib/Monomorphize.ml
@@ -38,9 +38,9 @@ let rec monomorphize_ty (env: env) (ty: stripped_ty): (mono_ty * env) =
      let (ty, env) = monomorphize_ty env ty in
      let (region, env) = monomorphize_ty env region in
      (MonoWriteRef (ty, region), env)
-  | SRawPointer ty ->
+  | SAddress ty ->
      let (ty, env) = monomorphize_ty env ty in
-     (MonoRawPointer ty, env)
+     (MonoAddress ty, env)
   | SNamedType (name, args) ->
      let (args, env) = monomorphize_ty_list env args in
      (match get_decl_by_name env (qident_to_sident name) with
@@ -765,7 +765,7 @@ and mono_to_ty (ty: mono_ty): ty =
      ReadRef (r ty, r region)
   | MonoWriteRef (ty, region) ->
      WriteRef (r ty, r region)
-  | MonoRawPointer ty ->
-     RawPointer (r ty)
+  | MonoAddress ty ->
+     Address (r ty)
   | MonoRegionTyVar (name, source) ->
      TyVar (TypeVariable (name, RegionUniverse, source))

--- a/lib/Monomorphize.ml
+++ b/lib/Monomorphize.ml
@@ -41,6 +41,9 @@ let rec monomorphize_ty (env: env) (ty: stripped_ty): (mono_ty * env) =
   | SAddress ty ->
      let (ty, env) = monomorphize_ty env ty in
      (MonoAddress ty, env)
+  | SPointer ty ->
+     let (ty, env) = monomorphize_ty env ty in
+     (MonoPointer ty, env)
   | SNamedType (name, args) ->
      let (args, env) = monomorphize_ty_list env args in
      (match get_decl_by_name env (qident_to_sident name) with
@@ -767,5 +770,7 @@ and mono_to_ty (ty: mono_ty): ty =
      WriteRef (r ty, r region)
   | MonoAddress ty ->
      Address (r ty)
+  | MonoPointer ty ->
+     Pointer (r ty)
   | MonoRegionTyVar (name, source) ->
      TyVar (TypeVariable (name, RegionUniverse, source))

--- a/lib/Monomorphize.ml
+++ b/lib/Monomorphize.ml
@@ -99,8 +99,6 @@ let rec monomorphize_expr (env: env) (expr: texpr): (mexpr * env) =
   | TStringConstant s ->
      (MStringConstant s, env)
   | TVariable (name, ty) ->
-     (*print_endline (qident_debug_name name);*)
-     (*print_endline ("Type: " ^ (show_ty ty));*)
      let (ty, env) = strip_and_mono env ty in
      (MVariable (name, ty), env)
   | TArithmetic (oper, lhs, rhs) ->

--- a/lib/Mtast.ml
+++ b/lib/Mtast.ml
@@ -52,7 +52,9 @@ and mexpr =
   | MIntConstant of string
   | MFloatConstant of string
   | MStringConstant of escaped_string
-  | MVariable of qident * mono_ty
+  | MConstVar of qident * mono_ty
+  | MParamVar of identifier * mono_ty
+  | MLocalVar of identifier * mono_ty
   | MArithmetic of arithmetic_operator * mexpr * mexpr
   | MConcreteFuncall of decl_id * qident * mexpr list * mono_ty
   (** Represents a call to a concrete function. *)
@@ -115,7 +117,11 @@ let rec get_type (e: mexpr): mono_ty =
      MonoDoubleFloat
   | MStringConstant _ ->
      err "Type of the string constant"
-  | MVariable (_, ty) ->
+  | MConstVar (_, ty) ->
+     ty
+  | MParamVar (_, ty) ->
+     ty
+  | MLocalVar (_, ty) ->
      ty
   | MArithmetic (_, lhs, _) ->
      get_type lhs

--- a/lib/Names.ml
+++ b/lib/Names.ml
@@ -1,0 +1,23 @@
+let unit_name = "Unit"
+let bool_name = "Boolean"
+
+let nat_prefix = "Natural_"
+let int_prefix = "Integer_"
+
+let nat8_name  = "Natural_8"
+let int8_name  = "Integer_8"
+let nat16_name = "Natural_16"
+let int16_name = "Integer_16"
+let nat32_name = "Natural_32"
+let int32_name = "Integer_32"
+let nat64_name = "Natural_64"
+let int64_name = "Integer_64"
+
+let single_float_name = "Single_Float"
+let double_float_name = "Double_Float"
+
+let read_ref_name  = "Reference"
+let write_ref_name = "WriteReference"
+
+let address_name = "Address"
+let pointer_name = "Pointer"

--- a/lib/Names.mli
+++ b/lib/Names.mli
@@ -1,0 +1,25 @@
+(** This module contains the names of language constructs. *)
+
+val unit_name : string
+val bool_name : string
+
+val nat_prefix : string
+val int_prefix : string
+
+val nat8_name  : string
+val int8_name  : string
+val nat16_name : string
+val int16_name : string
+val nat32_name : string
+val int32_name : string
+val nat64_name : string
+val int64_name : string
+
+val single_float_name : string
+val double_float_name : string
+
+val read_ref_name  : string
+val write_ref_name : string
+
+val address_name : string
+val pointer_name : string

--- a/lib/ParserInterface.ml
+++ b/lib/ParserInterface.ml
@@ -1,6 +1,7 @@
 open Cst
 open Span
 open Error
+open Reporter
 
 let parse' f (code: string) (filename: string) =
   let lexbuf = Lexing.from_string code in
@@ -13,10 +14,16 @@ let parse' f (code: string) (filename: string) =
         raise (Austral_error error)
 
 let parse_module_int (s:string) (filename: string): concrete_module_interface  =
-  parse' Parser.module_int s filename
+  with_frame "Parse module interface"
+    (fun _ ->
+      ps ("Filename", filename);
+      parse' Parser.module_int s filename)
 
 let parse_module_body (s: string) (filename: string): concrete_module_body =
-  parse' Parser.module_body s filename
+    with_frame "Parse module body"
+      (fun _ ->
+        ps ("Filename", filename);
+        parse' Parser.module_body s filename)
 
 let parse_stmt s =
   parse' Parser.standalone_statement s ""

--- a/lib/Reporter.ml
+++ b/lib/Reporter.ml
@@ -13,9 +13,24 @@ let events: event list ref = ref []
 let push_event (event: event): unit =
   events := (event :: !events)
 
+let prefix: string = "<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Austral Compiler Call Tree</title>
+  </head>
+  <body>
+<h1>Compiler Call Tree</h1>\n"
+
+let suffix: string = "
+  </body>
+</html>"
+
 (** Render the event list to HTML. *)
 let rec render _ : string =
-  String.concat "" (List.map render_event !events)
+  prefix
+ ^ (String.concat "" (List.map render_event !events))
+ ^ suffix
 
 and render_event (event: event): string =
   match event with

--- a/lib/Reporter.ml
+++ b/lib/Reporter.ml
@@ -1,3 +1,4 @@
+open Identifier
 open Util
 
 (** An event: either entering a frame, printing a value, or leaving a frame. *)
@@ -83,3 +84,6 @@ type label = string
 
 let ps ((label, value): (label * string)): unit =
   push_event (PrintValue (label, value))
+
+let pi ((label, value): (label * identifier)): unit =
+  push_event (PrintValue (label, ident_string value))

--- a/lib/Reporter.ml
+++ b/lib/Reporter.ml
@@ -1,4 +1,5 @@
 open Identifier
+open Type
 open Util
 
 (** An event: either entering a frame, printing a value, or leaving a frame. *)
@@ -87,3 +88,6 @@ let ps ((label, value): (label * string)): unit =
 
 let pi ((label, value): (label * identifier)): unit =
   push_event (PrintValue (label, ident_string value))
+
+let pt ((label, value): (label * ty)): unit =
+  push_event (PrintValue (label, type_string value))

--- a/lib/Reporter.ml
+++ b/lib/Reporter.ml
@@ -20,16 +20,23 @@ let prefix: string = "<!DOCTYPE html>
     <title>Austral Compiler Call Tree</title>
   </head>
   <body>
-<h1>Compiler Call Tree</h1>\n"
+<h1>Compiler Call Tree</h1>
+<ul>\n"
 
-let suffix: string = "
+let suffix: string = "</ul>
+  <style>
+    .multi-line {
+      display: flex;
+      flex-direction: row;
+    }
+  </style>
   </body>
 </html>"
 
 (** Render the event list to HTML. *)
 let rec render _ : string =
   prefix
- ^ (String.concat "" (List.map render_event !events))
+ ^ (String.concat "" (List.map render_event (List.rev !events)))
  ^ suffix
 
 and render_event (event: event): string =
@@ -42,10 +49,24 @@ and render_event (event: event): string =
      "</ul>
 </li>\n"
   | PrintValue (label, value) ->
-     "<li class='value'>
+     (match String.index_opt value '\n' with
+      | Some _ ->
+         (* Has a newline. *)
+         ("<li class='prop'>
+<div class='multi-line'>
 <span class='label'>" ^ label ^ "</span>
-<pre><code>" ^ value ^ "</pre></code>
-</li>\n"
+<pre class='value'><code>" ^ value ^ "</pre></code>
+</div>
+</li>\n")
+      | None ->
+         (* No newline. *)
+         ("<li class='prop'>
+<div class='single-line'>
+<span class='label'>" ^ label ^ "</span>
+<code class='value'>" ^ value ^ "</code>
+</div>
+</li>\n"))
+
 
 let dump _: unit =
   write_string_to_file "calltree.html" (render ())

--- a/lib/Reporter.ml
+++ b/lib/Reporter.ml
@@ -89,5 +89,8 @@ let ps ((label, value): (label * string)): unit =
 let pi ((label, value): (label * identifier)): unit =
   push_event (PrintValue (label, ident_string value))
 
+let pqi ((label, value): (label * qident)): unit =
+  push_event (PrintValue (label, qident_debug_name value))
+
 let pt ((label, value): (label * ty)): unit =
   push_event (PrintValue (label, type_string value))

--- a/lib/Reporter.mli
+++ b/lib/Reporter.mli
@@ -1,6 +1,7 @@
 (** The reporter keeps track of the compiler's call tree, and is useful for
     debugging crashes and bugs. *)
 open Identifier
+open Type
 
 (** Render the event list and dump it to a file. *)
 val dump : unit -> unit
@@ -16,3 +17,6 @@ val ps : (label * string) -> unit
 
 (** Push an identifier property to the current frame. *)
 val pi: (label * identifier) -> unit
+
+(** Push a type expression property to the current frame. *)
+val pt: (label * ty) -> unit

--- a/lib/Reporter.mli
+++ b/lib/Reporter.mli
@@ -18,5 +18,8 @@ val ps : (label * string) -> unit
 (** Push an identifier property to the current frame. *)
 val pi: (label * identifier) -> unit
 
+(** Push a qualified identifier property to the current frame. *)
+val pqi: (label * qident) -> unit
+
 (** Push a type expression property to the current frame. *)
 val pt: (label * ty) -> unit

--- a/lib/Reporter.mli
+++ b/lib/Reporter.mli
@@ -1,5 +1,6 @@
 (** The reporter keeps track of the compiler's call tree, and is useful for
     debugging crashes and bugs. *)
+open Identifier
 
 (** Render the event list and dump it to a file. *)
 val dump : unit -> unit
@@ -12,3 +13,6 @@ type label = string
 
 (** Push a string property to the current frame. *)
 val ps : (label * string) -> unit
+
+(** Push an identifier property to the current frame. *)
+val pi: (label * identifier) -> unit

--- a/lib/Tast.ml
+++ b/lib/Tast.ml
@@ -38,7 +38,9 @@ and texpr =
   | TIntConstant of string
   | TFloatConstant of string
   | TStringConstant of escaped_string
-  | TVariable of qident * ty
+  | TConstVar of qident * ty
+  | TParamVar of identifier * ty
+  | TLocalVar of identifier * ty
   | TArithmetic of arithmetic_operator * texpr * texpr
   | TFuncall of decl_id * qident * texpr list * ty * (identifier * ty) list
   | TMethodCall of ins_meth_id * qident * type_parameter list * texpr list * ty * (identifier * ty) list
@@ -135,7 +137,11 @@ let rec get_type = function
      DoubleFloat
   | TStringConstant _ ->
      string_type
-  | TVariable (_, ty) ->
+  | TConstVar (_, ty) ->
+     ty
+  | TParamVar (_, ty) ->
+     ty
+  | TLocalVar (_, ty) ->
      ty
   | TArithmetic (_, lhs, _) ->
      get_type lhs

--- a/lib/Tast.mli
+++ b/lib/Tast.mli
@@ -36,7 +36,9 @@ and texpr =
   | TIntConstant of string
   | TFloatConstant of string
   | TStringConstant of escaped_string
-  | TVariable of qident * ty
+  | TConstVar of qident * ty
+  | TParamVar of identifier * ty
+  | TLocalVar of identifier * ty
   | TArithmetic of arithmetic_operator * texpr * texpr
   | TFuncall of decl_id * qident * texpr list * ty * (identifier * ty) list
   | TMethodCall of ins_meth_id * qident * type_parameter list * texpr list * ty * (identifier * ty) list

--- a/lib/Type.ml
+++ b/lib/Type.ml
@@ -1,6 +1,7 @@
 open Id
 open Identifier
 open Region
+open Names
 open Error
 
 type universe =
@@ -40,7 +41,7 @@ type ty =
   | ReadRef of ty * ty
   | WriteRef of ty * ty
   | TyVar of type_var
-  | RawPointer of ty
+  | Address of ty
   | MonoTy of mono_id
 [@@deriving show]
 
@@ -61,15 +62,15 @@ let universe_string = function
 
 let rec type_string = function
   | Unit ->
-     "Unit"
+     unit_name
   | Boolean ->
-     "Boolean"
+     bool_name
   | Integer (s, w) ->
-     (signedness_string s) ^ "_" ^ (width_string w)
+     (signedness_string s) ^ (width_string w)
   | SingleFloat ->
-     "SingleFloat"
+     single_float_name
   | DoubleFloat ->
-     "DoubleFloat"
+     double_float_name
   | NamedType (n, args, u) ->
      (ident_string (local_name n)) ^ args_string args ^ " : " ^ (universe_string u)
   | Array (t, r) ->
@@ -77,19 +78,19 @@ let rec type_string = function
   | RegionTy r ->
      ident_string (region_name r) ^ "(" ^ (string_of_int (region_id r)) ^ ")"
   | ReadRef (t, r) ->
-     "Reference[" ^ (type_string t) ^ ", " ^ (type_string r) ^ "] : Free"
+     read_ref_name ^ "[" ^ (type_string t) ^ ", " ^ (type_string r) ^ "] : Free"
   | WriteRef (t, r) ->
-     "WriteReference[" ^ (type_string t) ^ ", " ^ (type_string r) ^ "] : Linear"
+     write_ref_name ^ "[" ^ (type_string t) ^ ", " ^ (type_string r) ^ "] : Linear"
   | TyVar (TypeVariable (n, u, from)) ->
      (ident_string n) ^ "(" ^ (qident_debug_name from) ^ ")" ^ " : " ^ (universe_string u)
-  | RawPointer ty ->
-    "Pointer[" ^ (type_string ty) ^ "]"
+  | Address ty ->
+    address_name ^ "[" ^ (type_string ty) ^ "]"
   | MonoTy _ ->
     err "Not applicable"
 
 and signedness_string = function
-  | Unsigned -> "Natural"
-  | Signed -> "Integer"
+  | Unsigned -> nat_prefix
+  | Signed -> int_prefix
 
 and width_int = function
   | Width8 -> 8
@@ -177,9 +178,9 @@ let rec equal_ty a b =
          equal_type_var v v'
       | _ ->
          false)
-  | RawPointer ty ->
+  | Address ty ->
      (match b with
-      | RawPointer ty' ->
+      | Address ty' ->
          equal_ty ty ty'
       | _ ->
         false)

--- a/lib/Type.ml
+++ b/lib/Type.ml
@@ -2,7 +2,6 @@ open Id
 open Identifier
 open Region
 open Names
-open Error
 
 type universe =
   | FreeUniverse
@@ -73,23 +72,23 @@ let rec type_string = function
   | DoubleFloat ->
      double_float_name
   | NamedType (n, args, u) ->
-     (ident_string (local_name n)) ^ args_string args ^ " : " ^ (universe_string u)
+     (qident_debug_name n) ^ args_string args ^ ": " ^ (universe_string u)
   | Array (t, r) ->
-     "Array[" ^ (type_string t) ^ ", " ^ (ident_string (region_name r)) ^ "] : Free"
+     "Array[" ^ (type_string t) ^ ", " ^ (ident_string (region_name r)) ^ "]: Free"
   | RegionTy r ->
      ident_string (region_name r) ^ "(" ^ (string_of_int (region_id r)) ^ ")"
   | ReadRef (t, r) ->
-     read_ref_name ^ "[" ^ (type_string t) ^ ", " ^ (type_string r) ^ "] : Free"
+     read_ref_name ^ "[" ^ (type_string t) ^ ", " ^ (type_string r) ^ "]: Free"
   | WriteRef (t, r) ->
-     write_ref_name ^ "[" ^ (type_string t) ^ ", " ^ (type_string r) ^ "] : Linear"
+     write_ref_name ^ "[" ^ (type_string t) ^ ", " ^ (type_string r) ^ "]: Linear"
   | TyVar (TypeVariable (n, u, from)) ->
-     (ident_string n) ^ "(" ^ (qident_debug_name from) ^ ")" ^ " : " ^ (universe_string u)
+     (ident_string n) ^ "(" ^ (qident_debug_name from) ^ ")" ^ ": " ^ (universe_string u)
   | Address ty ->
      address_name ^ "[" ^ (type_string ty) ^ "]"
   | Pointer ty ->
      pointer_name ^ "[" ^ (type_string ty) ^ "]"
   | MonoTy _ ->
-    err "Not applicable"
+    "MonoTy"
 
 and signedness_string = function
   | Unsigned -> nat_prefix

--- a/lib/Type.ml
+++ b/lib/Type.ml
@@ -42,6 +42,7 @@ type ty =
   | WriteRef of ty * ty
   | TyVar of type_var
   | Address of ty
+  | Pointer of ty
   | MonoTy of mono_id
 [@@deriving show]
 
@@ -84,7 +85,9 @@ let rec type_string = function
   | TyVar (TypeVariable (n, u, from)) ->
      (ident_string n) ^ "(" ^ (qident_debug_name from) ^ ")" ^ " : " ^ (universe_string u)
   | Address ty ->
-    address_name ^ "[" ^ (type_string ty) ^ "]"
+     address_name ^ "[" ^ (type_string ty) ^ "]"
+  | Pointer ty ->
+     pointer_name ^ "[" ^ (type_string ty) ^ "]"
   | MonoTy _ ->
     err "Not applicable"
 
@@ -181,6 +184,12 @@ let rec equal_ty a b =
   | Address ty ->
      (match b with
       | Address ty' ->
+         equal_ty ty ty'
+      | _ ->
+        false)
+  | Pointer ty ->
+     (match b with
+      | Pointer ty' ->
          equal_ty ty ty'
       | _ ->
         false)

--- a/lib/Type.mli
+++ b/lib/Type.mli
@@ -40,6 +40,7 @@ type ty =
   | WriteRef of ty * ty
   | TyVar of type_var
   | Address of ty
+  | Pointer of ty
   | MonoTy of mono_id
   (** Special case, see the `mono_to_ty` function. We need this to be able to do
      monomorph instantiation, but this doesn't correspond to anything in the

--- a/lib/Type.mli
+++ b/lib/Type.mli
@@ -39,7 +39,7 @@ type ty =
   | ReadRef of ty * ty
   | WriteRef of ty * ty
   | TyVar of type_var
-  | RawPointer of ty
+  | Address of ty
   | MonoTy of mono_id
   (** Special case, see the `mono_to_ty` function. We need this to be able to do
      monomorph instantiation, but this doesn't correspond to anything in the

--- a/lib/TypeBindings.ml
+++ b/lib/TypeBindings.ml
@@ -9,16 +9,14 @@ module BindingsMap =
         open Identifier
         type t = (identifier * qident)
         let compare (n, f) (n', f') =
-          let qs (qname: qident) =
+          (* Turn a qident into a string. *)
+          let qs (qname: qident): string =
             (mod_name_string (source_module_name qname))
             ^ (ident_string (original_name qname))
             ^ (ident_string (local_name qname))
           in
-          let _ = (qs, f, f') in
-          let a =
-            (ident_string n)
-          and b =
-            (ident_string n')
+          let a = (ident_string n) ^ (qs f)
+          and b = (ident_string n') ^ (qs f')
           in
           compare a b
       end

--- a/lib/TypeBindings.ml
+++ b/lib/TypeBindings.ml
@@ -127,6 +127,8 @@ let rec replace_variables bindings ty =
      WriteRef (replace_variables bindings ty, replace_variables bindings region)
   | Address ty ->
      Address (replace_variables bindings ty)
+  | Pointer ty ->
+     Pointer (replace_variables bindings ty)
   | MonoTy id ->
      MonoTy id
 

--- a/lib/TypeBindings.ml
+++ b/lib/TypeBindings.ml
@@ -125,8 +125,8 @@ let rec replace_variables bindings ty =
      ReadRef (replace_variables bindings ty, replace_variables bindings region)
   | WriteRef (ty, region) ->
      WriteRef (replace_variables bindings ty, replace_variables bindings region)
-  | RawPointer ty ->
-     RawPointer (replace_variables bindings ty)
+  | Address ty ->
+     Address (replace_variables bindings ty)
   | MonoTy id ->
      MonoTy id
 

--- a/lib/TypeMatch.ml
+++ b/lib/TypeMatch.ml
@@ -109,9 +109,9 @@ let rec match_type a b =
          type_mismatch "Expected a write reference, but got another type." a b)
   | TyVar tyvar ->
      match_type_var tyvar b
-  | RawPointer t ->
+  | Address t ->
      (match b with
-      | RawPointer t' ->
+      | Address t' ->
          match_type t t'
       | TyVar tyvar ->
          match_type_var tyvar a

--- a/lib/TypeMatch.ml
+++ b/lib/TypeMatch.ml
@@ -117,6 +117,14 @@ let rec match_type a b =
          match_type_var tyvar a
       | _ ->
         type_mismatch "Expected an Address, but got another type." a b)
+  | Pointer t ->
+     (match b with
+      | Pointer t' ->
+         match_type t t'
+      | TyVar tyvar ->
+         match_type_var tyvar a
+      | _ ->
+        type_mismatch "Expected a Pointer, but got another type." a b)
   | MonoTy _ ->
     err "Not applicable"
 

--- a/lib/TypeMatch.ml
+++ b/lib/TypeMatch.ml
@@ -116,7 +116,7 @@ let rec match_type a b =
       | TyVar tyvar ->
          match_type_var tyvar a
       | _ ->
-        type_mismatch "Expected a Pointer, but got another type." a b)
+        type_mismatch "Expected an Address, but got another type." a b)
   | MonoTy _ ->
     err "Not applicable"
 

--- a/lib/TypeParser.ml
+++ b/lib/TypeParser.ml
@@ -1,10 +1,10 @@
 open Identifier
+open Names
 open Type
 open TypeSystem
 open Region
 open Ast
 open Env
-open BuiltIn
 open Error
 
 let decl_type_signature (decl: decl): type_signature option =
@@ -28,13 +28,22 @@ let decl_type_signature (decl: decl): type_signature option =
   | Instance _ ->
      None
 
+let memory_module_name = make_mod_name "Austral.Memory"
+
+let is_address_type (name: qident): bool =
+  let s = source_module_name name
+  and o = original_name name
+  in
+  (equal_module_name s memory_module_name)
+  && (equal_identifier o (make_ident address_name))
+
 let parse_built_in_type (name: qident) (args: ty list): ty option =
-  if is_pointer_type name then
+  if is_address_type name then
     match args with
     | [ty] ->
-       Some (RawPointer ty)
+       Some (Address ty)
     | _ ->
-       err "Invalid Pointer type specifier."
+       err "Invalid Address type specifier."
   else
     let name_str: string = ident_string (original_name name) in
     match name_str with

--- a/lib/TypeParser.ml
+++ b/lib/TypeParser.ml
@@ -37,6 +37,13 @@ let is_address_type (name: qident): bool =
   (equal_module_name s memory_module_name)
   && (equal_identifier o (make_ident address_name))
 
+let is_pointer_type (name: qident): bool =
+  let s = source_module_name name
+  and o = original_name name
+  in
+  (equal_module_name s memory_module_name)
+  && (equal_identifier o (make_ident pointer_name))
+
 let parse_built_in_type (name: qident) (args: ty list): ty option =
   if is_address_type name then
     match args with
@@ -45,70 +52,78 @@ let parse_built_in_type (name: qident) (args: ty list): ty option =
     | _ ->
        err "Invalid Address type specifier."
   else
-    let name_str: string = ident_string (original_name name) in
-    match name_str with
-    | "Unit" ->
-       Some Unit
-    | "Boolean" ->
-       Some Boolean
-    | "Natural_8" ->
-       Some (Integer (Unsigned, Width8))
-    | "Natural_16" ->
-       Some (Integer (Unsigned, Width16))
-    | "Natural_32" ->
-       Some (Integer (Unsigned, Width32))
-    | "Natural_64" ->
-       Some (Integer (Unsigned, Width64))
-    | "Integer_8" ->
-       Some (Integer (Signed, Width8))
-    | "Integer_16" ->
-       Some (Integer (Signed, Width16))
-    | "Integer_32" ->
-       Some (Integer (Signed, Width32))
-    | "Integer_64" ->
-       Some (Integer (Signed, Width64))
-    | "Single_Float" ->
-       Some SingleFloat
-    | "Double_Float" ->
-       Some DoubleFloat
-    | "Static" ->
-       Some (RegionTy static_region)
-    | "Fixed_Array" ->
-       (match args with
-        | [ty] ->
-           Some (Array (ty, static_region))
-        | _ ->
-           err "Invalid Fixed_Array type specifier.")
-    | "Reference" ->
-       (match args with
-        | [ty; ty'] ->
-           let u = type_universe ty' in
-           if (u = RegionUniverse) then
-             Some (ReadRef (ty, ty'))
-           else
-             err "Reference error: Not a region"
-        | _ ->
-           err "Invalid Reference type specifier.")
-    | "WriteReference" ->
-       (match args with
-        | [ty; ty'] ->
-           let u' = type_universe ty' in
-           if (u' = RegionUniverse) then
-             Some (WriteRef (ty, ty'))
-           else
-             err "WriteReference error: Not a region"
-        | _ ->
-           err "Invalid WriteReference type specifier.")
-    | _ ->
-       None
+    if is_pointer_type name then
+      match args with
+      | [ty] ->
+         Some (Pointer ty)
+      | _ ->
+         err "Invalid Pointer type specifier."
+    else
+      let name_str: string = ident_string (original_name name) in
+      match name_str with
+      | "Unit" ->
+         Some Unit
+      | "Boolean" ->
+         Some Boolean
+      | "Natural_8" ->
+         Some (Integer (Unsigned, Width8))
+      | "Natural_16" ->
+         Some (Integer (Unsigned, Width16))
+      | "Natural_32" ->
+         Some (Integer (Unsigned, Width32))
+      | "Natural_64" ->
+         Some (Integer (Unsigned, Width64))
+      | "Integer_8" ->
+         Some (Integer (Signed, Width8))
+      | "Integer_16" ->
+         Some (Integer (Signed, Width16))
+      | "Integer_32" ->
+         Some (Integer (Signed, Width32))
+      | "Integer_64" ->
+         Some (Integer (Signed, Width64))
+      | "Single_Float" ->
+         Some SingleFloat
+      | "Double_Float" ->
+         Some DoubleFloat
+      | "Static" ->
+         Some (RegionTy static_region)
+      | "Fixed_Array" ->
+         (match args with
+          | [ty] ->
+             Some (Array (ty, static_region))
+          | _ ->
+             err "Invalid Fixed_Array type specifier.")
+      | "Reference" ->
+         (match args with
+          | [ty; ty'] ->
+             let u = type_universe ty' in
+             if (u = RegionUniverse) then
+               Some (ReadRef (ty, ty'))
+             else
+               err "Reference error: Not a region"
+          | _ ->
+             err "Invalid Reference type specifier.")
+      | "WriteReference" ->
+         (match args with
+          | [ty; ty'] ->
+             let u' = type_universe ty' in
+             if (u' = RegionUniverse) then
+               Some (WriteRef (ty, ty'))
+             else
+               err "WriteReference error: Not a region"
+          | _ ->
+             err "Invalid WriteReference type specifier.")
+      | _ ->
+         None
 
 let rec effective_universe name typarams declared_universe args =
   (* Algorithm:
 
      1. If the declared universe is Free then none of the type parameters can be Linear or Type.
 
-         1.1 Unless it's `Pointer[T]`. But we don't have to take care of that here, since `Pointer`
-             is a built in type, and the `type_universe` function determines its universe.
+         1.1 Unless it's `Pointer[T]` or `Address[T]`. But we don't have to take
+         care of that here, since those are built in types, and the
+         `type_universe` function determines their universe.
 
      2. If the declared universe is Linear, then no type parameter can change this. Therefore, the effective
         universe is Linear.

--- a/lib/TypeReplace.ml
+++ b/lib/TypeReplace.ml
@@ -14,9 +14,15 @@ let rec replace_tyvars_expr (bindings: type_bindings) (expr: texpr): texpr =
      TFloatConstant f
   | TStringConstant s ->
      TStringConstant s
-  | TVariable (name, ty) ->
+  | TConstVar (name, ty) ->
      let ty = replace_variables bindings ty in
-     TVariable (name, ty)
+     TConstVar (name, ty)
+  | TParamVar (name, ty) ->
+     let ty = replace_variables bindings ty in
+     TParamVar (name, ty)
+  | TLocalVar (name, ty) ->
+     let ty = replace_variables bindings ty in
+     TLocalVar (name, ty)
   | TArithmetic (oper, lhs, rhs) ->
      let lhs = replace_tyvars_expr bindings lhs
      and rhs = replace_tyvars_expr bindings rhs in

--- a/lib/TypeReplace.ml
+++ b/lib/TypeReplace.ml
@@ -15,10 +15,7 @@ let rec replace_tyvars_expr (bindings: type_bindings) (expr: texpr): texpr =
   | TStringConstant s ->
      TStringConstant s
   | TVariable (name, ty) ->
-     (*print_endline ("Bindings: " ^ (show_bindings bindings));*)
-     (*print_endline ("Type before: " ^ (show_ty ty));*)
      let ty = replace_variables bindings ty in
-     (*print_endline ("Type after: " ^ (show_ty ty));*)
      TVariable (name, ty)
   | TArithmetic (oper, lhs, rhs) ->
      let lhs = replace_tyvars_expr bindings lhs

--- a/lib/TypeStripping.ml
+++ b/lib/TypeStripping.ml
@@ -23,9 +23,9 @@ type stripped_ty =
 let rec strip_type (ty: ty): stripped_ty =
   match strip_type' ty with
   | Some ty ->
-    ty
+     ty
   | None ->
-    err "strip_type called with a region type as its argument"
+     err "strip_type called with a region type as its argument"
 
 and strip_type' (ty: ty): stripped_ty option =
   match ty with
@@ -84,6 +84,12 @@ and strip_type' (ty: ty): stripped_ty option =
       | Some ty ->
          Some (SAddress ty)
       | None ->
-         err "Internal: raw pointer type instantiated with a region type.")
+         err "Internal: Address type instantiated with a region type.")
+  | Pointer ty ->
+     (match (strip_type' ty) with
+      | Some ty ->
+         Some (SPointer ty)
+      | None ->
+         err "Internal: Pointer type instantiated with a region type.")
   | MonoTy id ->
      Some (SMonoTy id)

--- a/lib/TypeStripping.ml
+++ b/lib/TypeStripping.ml
@@ -30,45 +30,45 @@ let rec strip_type (ty: ty): stripped_ty =
 and strip_type' (ty: ty): stripped_ty option =
   match ty with
   | Unit ->
-    Some SUnit
+     Some SUnit
   | Boolean ->
-    Some SBoolean
+     Some SBoolean
   | Integer (s, w) ->
-    Some (SInteger (s, w))
+     Some (SInteger (s, w))
   | SingleFloat ->
-    Some SSingleFloat
+     Some SSingleFloat
   | DoubleFloat ->
-    Some SDoubleFloat
+     Some SDoubleFloat
   | NamedType (n, args, _) ->
-    Some (SNamedType (n, List.filter_map strip_type' args))
+     Some (SNamedType (n, List.filter_map strip_type' args))
   | Array (elem_ty, r) ->
-    (match (strip_type' elem_ty) with
-     | Some elem_ty ->
-       Some (SArray (elem_ty, r))
-     | None ->
-       err "Internal: array instantiated with a region type.")
+     (match (strip_type' elem_ty) with
+      | Some elem_ty ->
+         Some (SArray (elem_ty, r))
+      | None ->
+         err "Internal: array instantiated with a region type.")
   | RegionTy r ->
-    Some (SRegionTy r)
+     Some (SRegionTy r)
   | ReadRef (ty, r) ->
-    (match (strip_type' ty) with
-     | Some ty ->
-       (match (strip_type' r) with
-        | Some r ->
-          Some (SReadRef (ty, r))
-        | None ->
-          err "internal")
-     | None ->
-       err "Internal: read ref instantiated with a region type.")
+     (match (strip_type' ty) with
+      | Some ty ->
+         (match (strip_type' r) with
+          | Some r ->
+             Some (SReadRef (ty, r))
+          | None ->
+             err "internal")
+      | None ->
+         err "Internal: read ref instantiated with a region type.")
   | WriteRef (ty, r) ->
-    (match (strip_type' ty) with
-     | Some ty ->
-       (match (strip_type' r) with
-        | Some r ->
-          Some (SWriteRef (ty, r))
-        | None ->
-          err "internal")
-     | None ->
-       err "Internal: write ref instantiated with a region type.")
+     (match (strip_type' ty) with
+      | Some ty ->
+         (match (strip_type' r) with
+          | Some r ->
+             Some (SWriteRef (ty, r))
+          | None ->
+             err "internal")
+      | None ->
+         err "Internal: write ref instantiated with a region type.")
   | TyVar (TypeVariable (name, u, source)) ->
      if u = RegionUniverse then
        Some (SRegionTyVar (name, source))
@@ -80,10 +80,10 @@ and strip_type' (ty: ty): stripped_ty option =
           type variable has no replacement. *)
        err ("strip_type': Variable not replaced: '" ^ (ident_string name) ^ "'")
   | Address ty ->
-    (match (strip_type' ty) with
-     | Some ty ->
-       Some (SAddress ty)
-     | None ->
-       err "Internal: raw pointer type instantiated with a region type.")
+     (match (strip_type' ty) with
+      | Some ty ->
+         Some (SAddress ty)
+      | None ->
+         err "Internal: raw pointer type instantiated with a region type.")
   | MonoTy id ->
-    Some (SMonoTy id)
+     Some (SMonoTy id)

--- a/lib/TypeStripping.ml
+++ b/lib/TypeStripping.ml
@@ -15,7 +15,7 @@ type stripped_ty =
   | SRegionTy of region
   | SReadRef of stripped_ty * stripped_ty
   | SWriteRef of stripped_ty * stripped_ty
-  | SRawPointer of stripped_ty
+  | SAddress of stripped_ty
   | SMonoTy of mono_id
   | SRegionTyVar of identifier * qident
 
@@ -78,10 +78,10 @@ and strip_type' (ty: ty): stripped_ty option =
           search-and-replace step should *also* have signalled an error if a
           type variable has no replacement. *)
        err ("strip_type': Variable not replaced: '" ^ (ident_string name) ^ "'")
-  | RawPointer ty ->
+  | Address ty ->
     (match (strip_type' ty) with
      | Some ty ->
-       Some (SRawPointer ty)
+       Some (SAddress ty)
      | None ->
        err "Internal: raw pointer type instantiated with a region type.")
   | MonoTy id ->

--- a/lib/TypeStripping.ml
+++ b/lib/TypeStripping.ml
@@ -16,6 +16,7 @@ type stripped_ty =
   | SReadRef of stripped_ty * stripped_ty
   | SWriteRef of stripped_ty * stripped_ty
   | SAddress of stripped_ty
+  | SPointer of stripped_ty
   | SMonoTy of mono_id
   | SRegionTyVar of identifier * qident
 

--- a/lib/TypeStripping.mli
+++ b/lib/TypeStripping.mli
@@ -18,8 +18,9 @@ type stripped_ty =
   | SArray of stripped_ty * region
   | SRegionTy of region
   | SReadRef of stripped_ty * stripped_ty
-  | SWriteRef of stripped_ty * stripped_ty
+  | SWriteRef of stripped_ty *
   | SAddress of stripped_ty
+  | SPointer of stripped_ty
   | SMonoTy of mono_id
   | SRegionTyVar of identifier * qident
 

--- a/lib/TypeStripping.mli
+++ b/lib/TypeStripping.mli
@@ -18,7 +18,7 @@ type stripped_ty =
   | SArray of stripped_ty * region
   | SRegionTy of region
   | SReadRef of stripped_ty * stripped_ty
-  | SWriteRef of stripped_ty *
+  | SWriteRef of stripped_ty * stripped_ty
   | SAddress of stripped_ty
   | SPointer of stripped_ty
   | SMonoTy of mono_id

--- a/lib/TypeStripping.mli
+++ b/lib/TypeStripping.mli
@@ -19,7 +19,7 @@ type stripped_ty =
   | SRegionTy of region
   | SReadRef of stripped_ty * stripped_ty
   | SWriteRef of stripped_ty * stripped_ty
-  | SRawPointer of stripped_ty
+  | SAddress of stripped_ty
   | SMonoTy of mono_id
   | SRegionTyVar of identifier * qident
 

--- a/lib/TypeSystem.ml
+++ b/lib/TypeSystem.ml
@@ -16,6 +16,7 @@ let type_universe = function
   | WriteRef _ -> FreeUniverse
   | TyVar (TypeVariable (_, u, _)) -> u
   | Address _ -> FreeUniverse
+  | Pointer _ -> FreeUniverse
   | MonoTy _ -> err "Not applicable"
 
 let is_numeric = function
@@ -31,6 +32,7 @@ let is_numeric = function
   | WriteRef _ -> false
   | TyVar _ -> false
   | Address _ -> false
+  | Pointer -> false
   | MonoTy _ -> err "Not applicable"
 
 let is_comparable = function
@@ -46,6 +48,7 @@ let is_comparable = function
   | WriteRef _ -> false
   | TyVar _ -> false
   | Address _ -> true
+  | Pointer _ -> true
   | MonoTy _ -> err "Not applicable"
 
 let rec type_variables = function
@@ -73,6 +76,8 @@ let rec type_variables = function
      TypeVarSet.singleton v
   | Address ty ->
      type_variables ty
+  | Pointer ty ->
+     type_variables ty
   | MonoTy _ ->
     TypeVarSet.empty
 
@@ -98,6 +103,8 @@ let rec is_concrete = function
      (* Individual type variables need not be instantiated. *)
      true
   | Address _ ->
-    true
+     true
+  | Pointer _ ->
+     true
   | MonoTy _ ->
     true

--- a/lib/TypeSystem.ml
+++ b/lib/TypeSystem.ml
@@ -15,7 +15,7 @@ let type_universe = function
   | ReadRef _ -> FreeUniverse
   | WriteRef _ -> FreeUniverse
   | TyVar (TypeVariable (_, u, _)) -> u
-  | RawPointer _ -> FreeUniverse
+  | Address _ -> FreeUniverse
   | MonoTy _ -> err "Not applicable"
 
 let is_numeric = function
@@ -30,7 +30,7 @@ let is_numeric = function
   | ReadRef _ -> false
   | WriteRef _ -> false
   | TyVar _ -> false
-  | RawPointer _ -> false
+  | Address _ -> false
   | MonoTy _ -> err "Not applicable"
 
 let is_comparable = function
@@ -45,7 +45,7 @@ let is_comparable = function
   | ReadRef _ -> false
   | WriteRef _ -> false
   | TyVar _ -> false
-  | RawPointer _ -> true
+  | Address _ -> true
   | MonoTy _ -> err "Not applicable"
 
 let rec type_variables = function
@@ -71,7 +71,7 @@ let rec type_variables = function
      TypeVarSet.union (type_variables ty) (type_variables r)
   | TyVar v ->
      TypeVarSet.singleton v
-  | RawPointer ty ->
+  | Address ty ->
      type_variables ty
   | MonoTy _ ->
     TypeVarSet.empty
@@ -97,7 +97,7 @@ let rec is_concrete = function
   | TyVar _ ->
      (* Individual type variables need not be instantiated. *)
      true
-  | RawPointer _ ->
+  | Address _ ->
     true
   | MonoTy _ ->
     true

--- a/lib/TypeSystem.ml
+++ b/lib/TypeSystem.ml
@@ -107,4 +107,4 @@ let rec is_concrete = function
   | Pointer _ ->
      true
   | MonoTy _ ->
-    true
+     true

--- a/lib/TypeSystem.ml
+++ b/lib/TypeSystem.ml
@@ -32,7 +32,7 @@ let is_numeric = function
   | WriteRef _ -> false
   | TyVar _ -> false
   | Address _ -> false
-  | Pointer -> false
+  | Pointer _ -> false
   | MonoTy _ -> err "Not applicable"
 
 let is_comparable = function

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -350,7 +350,8 @@ and augment_path_elem (env: env) (module_name: module_name) (rm: region_map) (ty
          err "Not a record type")
   | PointerSlotAccessor slot_name ->
      (match head_ty with
-      | RawPointer pointed_to ->
+      | Address pointed_to ->
+         (* TODO: Addresses should not be indexable. *)
          augment_pointer_slot_accessor_elem env module_name slot_name pointed_to
       | ReadRef (ty, _) ->
          (match ty with
@@ -965,7 +966,8 @@ and augment_lvalue_path_elem (env: env) (module_name: module_name) (rm: region_m
          err "Not a record type")
   | PointerSlotAccessor slot_name ->
      (match head_ty with
-      | RawPointer pointed_to ->
+      | Address pointed_to ->
+         (* TODO: addresses should not be indexable *)
          augment_pointer_slot_accessor_elem env module_name slot_name pointed_to
       | WriteRef (ty, _) ->
          (match ty with

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -967,6 +967,7 @@ let rec augment_stmt (ctx: stmt_ctx) (stmt: astmt): tstmt =
          adorn_error_with_span span
            (fun _ ->
              let e' = augment_expr module_name env rm typarams lexenv None e in
+             ps ("Expression", show_texpr e');
              let u = type_universe (get_type e') in
              if ((u = LinearUniverse) || (u = TypeUniverse)) then
                err "Discarding a linear value"

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -577,6 +577,12 @@ and augment_union_constructor (type_name: qident) (typarams: type_parameter list
     check_bindings typarams (merge_bindings bindings bindings');
     (* Check the resulting type is in the correct universe *)
     if universe_compatible universe (type_universe rt'') then
+      let _ =  print_endline "-------------" in
+      print_endline ("rt: " ^ (type_string rt));
+      print_endline ("rt': " ^ (type_string rt'));
+      print_endline ("rt'': " ^ (type_string rt''));
+      print_endline ("Tyargs: " ^ (String.concat ", " (List.map (fun (_, t) -> show_ty (get_type t)) args')));
+      print_endline "-------------";
       TUnionConstructor (rt'', case_name, List.map2 (fun a b -> (a, b)) slot_names arguments)
     else
       err "Universe mismatch"

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -960,9 +960,9 @@ let rec augment_stmt (ctx: stmt_ctx) (stmt: astmt): tstmt =
               | None ->
                  err "No variable with this name."))
       | ABlock (span, f, r) ->
-         TBlock (span,
-                 augment_stmt ctx f,
-                 augment_stmt ctx r)
+         let a = augment_stmt ctx f in
+         let b = augment_stmt ctx r in
+         TBlock (span, a, b)
       | ADiscarding (span, e) ->
          adorn_error_with_span span
            (fun _ ->
@@ -976,6 +976,7 @@ let rec augment_stmt (ctx: stmt_ctx) (stmt: astmt): tstmt =
          adorn_error_with_span span
            (fun _ ->
              let e' = augment_expr module_name env rm typarams lexenv None e in
+             pt ("Type", get_type e');
              let _ = match_type_with_value rt e' in
              TReturn (span, e')))
 
@@ -1067,6 +1068,9 @@ and augment_when (ctx: stmt_ctx) (typebindings: type_bindings) (w: abstract_when
         let bindings'' = List.map (fun (n, ty, actual) -> (n, parse_typespec menv rm typarams ty, replace_variables typebindings actual)) bindings' in
         let newvars = List.map (fun (n, ty, actual) ->
                           if equal_ty ty actual then
+                            let _ = pi ("Binding name", n)
+                            in
+                            pt ("Binding type",  ty);
                             (n, ty, VarLocal)
                           else
                             err ("Slot type mismatch: expected \n\n" ^ (type_string ty) ^ "\n\nbut got:\n\n" ^ (type_string actual)))

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -15,6 +15,7 @@ open Tast
 open Linked
 open Linearity
 open Util
+open Reporter
 open Error
 
 let get_instance (env: env) (source_module_name: module_name) (dispatch_ty: ty) (typeclass: decl_id): decl =
@@ -1117,43 +1118,53 @@ and is_path_elem_constant = function
      is_constant e
 
 let rec augment_decl (module_name: module_name) (kind: module_kind) (env: env) (decl: linked_definition): typed_decl =
-  match decl with
-  | LConstant (decl_id, vis, name, ty, expr, doc) ->
-     let expr' = augment_expr module_name env empty_region_map [] empty_lexenv (Some ty) expr in
-     let _ = match_type_with_value ty expr' in
-     let _ = validate_constant_expression expr' in
-     TConstant (decl_id, vis, name, ty, expr', doc)
-  | LTypeAlias (decl_id, vis, name, typarams, universe, ty, doc) ->
-     TTypeAlias (decl_id, vis, name, typarams, universe, ty, doc)
-  | LRecord (decl_id, vis, name, typarams, universe, slots, doc) ->
-     TRecord (decl_id, vis, name, typarams, universe, slots, doc)
-  | LUnion (decl_id, vis, name, typarams, universe, cases, doc) ->
-     TUnion (decl_id, vis, name, typarams, universe, cases, doc)
-  | LFunction (decl_id, vis, name, typarams, params, rt, body, doc, pragmas) ->
-     let rm = region_map_from_typarams typarams in
-     (match pragmas with
-      | [ForeignImportPragma s] ->
-         if typarams = [] then
-           if kind = UnsafeModule then
-             TForeignFunction (decl_id, vis, name, params, rt, s, doc)
-           else
-             err "Can't declare a foreign function in a safe module."
-         else
-           err "Foreign functions can't have type parameters."
-      | [] ->
-         let ctx = (module_name, env, rm, typarams, (lexenv_from_params params), rt) in
-         let body' = augment_stmt ctx body in
-         TFunction (decl_id, vis, name, typarams, params, rt, body', doc)
-      | _ ->
-         err "Invalid pragmas")
-  | LTypeclass (decl_id, vis, name, typaram, methods, doc) ->
-     let rm = region_map_from_typarams [typaram] in
-     TTypeClass (decl_id, vis, name, typaram, List.map (augment_method_decl env rm typaram) methods, doc)
-  | LInstance (decl_id, vis, name, typarams, arg, methods, doc) ->
-     (* TODO: the universe of the type parameter matches the universe of the type argument *)
-     (* TODO: Check the methods in the instance match the methods in the class *)
-     let rm = region_map_from_typarams typarams in
-     TInstance (decl_id, vis, name, typarams, arg, List.map (augment_method_def module_name env rm typarams) methods, doc)
+  with_frame "Augment declaration"
+    (fun _ ->
+      match decl with
+      | LConstant (decl_id, vis, name, ty, expr, doc) ->
+         ps ("Kind", "Constant");
+         let expr' = augment_expr module_name env empty_region_map [] empty_lexenv (Some ty) expr in
+         let _ = match_type_with_value ty expr' in
+         let _ = validate_constant_expression expr' in
+         TConstant (decl_id, vis, name, ty, expr', doc)
+      | LTypeAlias (decl_id, vis, name, typarams, universe, ty, doc) ->
+         ps ("Kind", "Type Alias");
+         TTypeAlias (decl_id, vis, name, typarams, universe, ty, doc)
+      | LRecord (decl_id, vis, name, typarams, universe, slots, doc) ->
+         ps ("Kind", "Record");
+         TRecord (decl_id, vis, name, typarams, universe, slots, doc)
+      | LUnion (decl_id, vis, name, typarams, universe, cases, doc) ->
+         ps ("Kind", "Union");
+         TUnion (decl_id, vis, name, typarams, universe, cases, doc)
+      | LFunction (decl_id, vis, name, typarams, params, rt, body, doc, pragmas) ->
+         ps ("Kind", "Function");
+         pi ("Name", name);
+         let rm = region_map_from_typarams typarams in
+         (match pragmas with
+          | [ForeignImportPragma s] ->
+             if typarams = [] then
+               if kind = UnsafeModule then
+                 TForeignFunction (decl_id, vis, name, params, rt, s, doc)
+               else
+                 err "Can't declare a foreign function in a safe module."
+             else
+               err "Foreign functions can't have type parameters."
+          | [] ->
+             let ctx = (module_name, env, rm, typarams, (lexenv_from_params params), rt) in
+             let body' = augment_stmt ctx body in
+             TFunction (decl_id, vis, name, typarams, params, rt, body', doc)
+          | _ ->
+             err "Invalid pragmas")
+      | LTypeclass (decl_id, vis, name, typaram, methods, doc) ->
+         ps ("Kind", "Typeclass");
+         let rm = region_map_from_typarams [typaram] in
+         TTypeClass (decl_id, vis, name, typaram, List.map (augment_method_decl env rm typaram) methods, doc)
+      | LInstance (decl_id, vis, name, typarams, arg, methods, doc) ->
+         ps ("Kind", "Instance");
+         (* TODO: the universe of the type parameter matches the universe of the type argument *)
+         (* TODO: Check the methods in the instance match the methods in the class *)
+         let rm = region_map_from_typarams typarams in
+         TInstance (decl_id, vis, name, typarams, arg, List.map (augment_method_def module_name env rm typarams) methods, doc))
 
 and lexenv_from_params (params: value_parameter list): lexenv =
   match params with
@@ -1171,6 +1182,8 @@ and augment_method_def module_name menv rm typarams (LMethodDef (ins_meth_id, na
   TypedMethodDef (ins_meth_id, name, params, rt, body')
 
 let augment_module menv (LinkedModule { name; decls; kind; _ }) =
-  let decls' = List.map (augment_decl name kind menv) decls in
-  let _ = List.map check_decl_linearity decls' in
-  TypedModule (name, decls')
+  with_frame "Typing pass"
+    (fun _ ->
+      let decls' = List.map (augment_decl name kind menv) decls in
+      let _ = List.map check_decl_linearity decls' in
+      TypedModule (name, decls'))

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -1057,6 +1057,7 @@ and augment_when (ctx: stmt_ctx) (typebindings: type_bindings) (w: abstract_when
       let (_, menv, rm, typarams, lexenv, _) = ctx in
       let (AbstractWhen (name, bindings, body)) = w
       and (TypedCase (_, slots)) = c in
+      pi ("Case name", name);
       (* Check the set of binding names is the same as the set of slots *)
       let binding_names = List.map (fun (n, _) -> n) bindings
       and slot_names = List.map (fun (TypedSlot (n, _)) -> n) slots in

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -809,10 +809,13 @@ let rec augment_stmt (ctx: stmt_ctx) (stmt: astmt): tstmt =
          adorn_error_with_span span
            (fun _ ->
              let expected_ty = parse_typespec env rm typarams ty in
+             pt ("Expected type", expected_ty);
              let value' = augment_expr module_name env rm typarams lexenv (Some expected_ty) value in
              let bindings = match_type_with_value expected_ty value' in
+             ps ("Bindings", show_bindings bindings);
              let ty = replace_variables bindings expected_ty in
              pt ("Type", ty);
+             pt ("Value type", get_type value');
              let lexenv' = push_var lexenv name ty VarLocal in
              let body' = augment_stmt (update_lexenv ctx lexenv') body in
              TLet (span, name, ty, value', body'))

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -359,7 +359,7 @@ and augment_path_elem (env: env) (module_name: module_name) (rm: region_map) (ty
          err "Not a record type")
   | PointerSlotAccessor slot_name ->
      (match head_ty with
-      | Address pointed_to ->
+      | Pointer pointed_to ->
          (* TODO: Addresses should not be indexable. *)
          augment_pointer_slot_accessor_elem env module_name slot_name pointed_to
       | ReadRef (ty, _) ->
@@ -1018,7 +1018,7 @@ and augment_lvalue_path_elem (env: env) (module_name: module_name) (rm: region_m
          err "Not a record type")
   | PointerSlotAccessor slot_name ->
      (match head_ty with
-      | Address pointed_to ->
+      | Pointer pointed_to ->
          (* TODO: addresses should not be indexable *)
          augment_pointer_slot_accessor_elem env module_name slot_name pointed_to
       | WriteRef (ty, _) ->

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -578,6 +578,8 @@ and augment_union_constructor (type_name: qident) (typarams: type_parameter list
         let arguments = arglist_to_positional (args, slot_names) in
         (* Check the list of params against the list of arguments *)
         let params = List.map (fun (TypedSlot (n, t)) -> ValueParameter (n, t)) slots in
+        ps ("Params", String.concat "\n" (List.map (fun (ValueParameter (n, t)) -> (ident_string n) ^ ": " ^ (type_string t)) params));
+        ps ("Arguments", String.concat "\n" (List.map show_texpr arguments));
         let bindings = check_argument_list params arguments in
         (* Use the bindings to get the effective return type *)
         let rt = NamedType (type_name,
@@ -585,6 +587,7 @@ and augment_union_constructor (type_name: qident) (typarams: type_parameter list
                             universe)
         in
         pt ("Type", rt);
+        ps ("Bindings", show_bindings bindings);
         let rt' = replace_variables bindings rt in
         pt ("Type'", rt');
         let (bindings', rt'') = handle_return_type_polymorphism case_name params rt' asserted_ty bindings in

--- a/test/ExampleProgramTest.ml
+++ b/test/ExampleProgramTest.ml
@@ -57,8 +57,8 @@ module body Example is
     end;
 
     function Main(root: Root_Capability): Root_Capability is
-        let char: Natural_8 := @embed(Natural_8, "$1 + $2", 90, 7);
-        Put_Character(char);
+        let c: Natural_8 := @embed(Natural_8, "$1 + $2", 90, 7);
+        Put_Character(c);
         return root;
     end;
 end module body.

--- a/test/TypeMatchTest.ml
+++ b/test/TypeMatchTest.ml
@@ -29,17 +29,17 @@ let test_successful_matches _ =
   let param = fnt "Option" [Unit]
   and arg = fnt "Option" [t] in
   meq param arg [("T", Unit)];
-  let param = RawPointer t
-  and arg = RawPointer Unit in
+  let param = Address t
+  and arg = Address Unit in
   meq param arg [("T", Unit)];
-  let param = RawPointer (RawPointer t)
-  and arg = RawPointer (RawPointer Unit) in
+  let param = Address (Address t)
+  and arg = Address (Address Unit) in
   meq param arg [("T", Unit)];
-  let param = fnt "A" [RawPointer t]
-  and arg = fnt "A" [RawPointer Unit] in
+  let param = fnt "A" [Address t]
+  and arg = fnt "A" [Address Unit] in
   meq param arg [("T", Unit)];
-  let param = fnt "A" [fnt "B" [RawPointer t]]
-  and arg = fnt "A" [fnt "B" [RawPointer Unit]] in
+  let param = fnt "A" [fnt "B" [Address t]]
+  and arg = fnt "A" [fnt "B" [Address Unit]] in
   meq param arg [("T", Unit)]
 
 let suite =


### PR DESCRIPTION
Fix #165

- [x] Rename `Pointer` to `Address`
- [x] Add a `Pointer` type that represents non-nullable pointers
- [x] Add a `Null_Check` (or some better name) function to convert an address to an optional pointer by performing a null check.
- [x] Update API and example code.
- [ ] Update pointer offset functions to check result is non-null.
- [x] Update code to ensure only pointers, not addresses, are navigable.