### PR TITLE
Fix the build

### DIFF
--- a/lib/Cli.ml
+++ b/lib/Cli.ml
@@ -4,11 +4,13 @@ open CliEngine
 open Error
 
 let rec main (args: string list): unit =
+  let _ = Printexc.record_backtrace true in
   try
     main' args;
     exit 0
   with Austral_error error ->
     Printf.eprintf "%s" (render_error_to_plain error);
+    print_endline ("Backtrace:\n" ^ (Printexc.get_backtrace ()));
     dump_and_die ()
 
 and main' (args: string list): unit =

--- a/lib/Cli.ml
+++ b/lib/Cli.ml
@@ -4,13 +4,11 @@ open CliEngine
 open Error
 
 let rec main (args: string list): unit =
-  let _ = Printexc.record_backtrace true in
   try
     main' args;
     exit 0
   with Austral_error error ->
     Printf.eprintf "%s" (render_error_to_plain error);
-    print_endline ("Backtrace:\n" ^ (Printexc.get_backtrace ()));
     dump_and_die ()
 
 and main' (args: string list): unit =

--- a/lib/CliEngine.ml
+++ b/lib/CliEngine.ml
@@ -119,7 +119,6 @@ and exec_compile (modules: mod_source list) (target: target): unit =
     (* Print errors *)
     let error: austral_error = try_adding_source_ctx error source_map in
     Printf.eprintf "%s" (render_error_to_plain error);
-    print_endline ("Backtrace:\n" ^ (Printexc.get_backtrace ()));
     dump_and_die ()
 
 and dump_and_die _: unit =

--- a/lib/MonoTypeBindings.ml
+++ b/lib/MonoTypeBindings.ml
@@ -32,3 +32,12 @@ let mono_bindings_from_list lst =
 
 let equal_mono_bindings (MonoTypeBindings a) (MonoTypeBindings b) =
   BindingsMap.equal equal_mono_ty a b
+
+let show_mono_type_bindings (MonoTypeBindings m) =
+  let show_binding (tp, t) =
+    (show_type_parameter tp) ^ " => " ^ (show_mono_ty t)
+  in
+  "MonoTypeBindings {" ^ (String.concat ", " (List.map show_binding (BindingsMap.bindings m))) ^ "}"
+
+let get_mono_binding (MonoTypeBindings m) tp =
+  BindingsMap.find_opt tp m

--- a/lib/MonoTypeBindings.mli
+++ b/lib/MonoTypeBindings.mli
@@ -12,3 +12,7 @@ val mono_bindings_as_list : mono_type_bindings -> (type_parameter * mono_ty) lis
 val mono_bindings_from_list : (type_parameter * mono_ty) list -> mono_type_bindings
 
 val equal_mono_bindings : mono_type_bindings -> mono_type_bindings -> bool
+
+val show_mono_type_bindings : mono_type_bindings -> string
+
+val get_mono_binding : mono_type_bindings -> type_parameter -> mono_ty option

--- a/lib/Monomorphize.ml
+++ b/lib/Monomorphize.ml
@@ -726,21 +726,12 @@ and monomorphize_case_list (env: env) (cases: typed_case list): (env * mono_case
 and replace_type_variables (typarams: typarams) (args: mono_type_bindings) (ty: ty): ty =
   with_frame "Replacing type variables"
     (fun _ ->
-      (*print_endline ("Typarams: " ^ (show_typarams typarams));
-      print_endline ("Args: " ^ (show_mono_type_bindings args));*)
       let bindings: type_bindings = make_bindings typarams args in
       replace_variables bindings ty)
 
 and make_bindings (typarams: typarams) (args: mono_type_bindings): type_bindings =
   with_frame "Make bindings"
     (fun _ ->
-      (* Given a list of type parameters, a list of monomorphic type arguments
-         (of the same length), return a type bindings object (implicitly
-         converting the `mono_ty` into a `ty`).
-         Ideally we shouldn't need to bring the type parameters, rather,
-         monomorphs should be stored in the environment with an `(identifier,
-         mono_ty)` map rather than as a bare list of monomorphic type
-         arguments. This is a TODO. *)
       let typarams = typarams_as_list typarams in
       if (List.length typarams) = (List.length (mono_bindings_as_list args)) then
         let pairs: (type_parameter * ty) list =
@@ -752,7 +743,6 @@ and make_bindings (typarams: typarams) (args: mono_type_bindings): type_bindings
                   err "Parameter not found."))
             typarams
         in
-        (*let _ = print_endline ("Pairs: " ^ (String.concat ", " (List.map (fun (tp, t) -> "(" ^ (ident_string (typaram_name tp)) ^ ", " ^ (show_ty t) ^ ")") pairs))) in*)
         let _ = ps ("Pairs", String.concat ", " (List.map (fun (tp, t) -> "(" ^ (show_type_parameter tp) ^ ", " ^ (show_ty t) ^ ")") pairs)) in
         let b = bindings_from_list pairs in
         ps ("Bindings", show_bindings b);

--- a/lib/TypeMatch.ml
+++ b/lib/TypeMatch.ml
@@ -127,7 +127,7 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
       | _ ->
          type_mismatch "Expected a function pointer, but got another type." a b)
   | MonoTy _ ->
-     err "Not applicable"
+     err "match_type called with MonoTy argument"
 
 and match_type_var (ctx: ctx) (tv: type_var) (ty: ty): type_bindings =
   let (TypeVariable (name, universe, from, constraints)) = tv in

--- a/lib/TypeSystem.ml
+++ b/lib/TypeSystem.ml
@@ -19,7 +19,7 @@ let type_universe = function
   | Address _ -> FreeUniverse
   | Pointer _ -> FreeUniverse
   | FnPtr _ -> FreeUniverse
-  | MonoTy _ -> FreeUniverse (*err "type_universe called with MonoTy argument"*)
+  | MonoTy _ -> FreeUniverse (* TODO: arguably this should error, but the compiler crashes if it errors *)
 
 let is_numeric = function
   | Unit -> false

--- a/lib/TypeSystem.ml
+++ b/lib/TypeSystem.ml
@@ -19,7 +19,7 @@ let type_universe = function
   | Address _ -> FreeUniverse
   | Pointer _ -> FreeUniverse
   | FnPtr _ -> FreeUniverse
-  | MonoTy _ -> err "type_universe called with MonoTy argument"
+  | MonoTy _ -> FreeUniverse (*err "type_universe called with MonoTy argument"*)
 
 let is_numeric = function
   | Unit -> false

--- a/lib/TypeSystem.ml
+++ b/lib/TypeSystem.ml
@@ -19,7 +19,7 @@ let type_universe = function
   | Address _ -> FreeUniverse
   | Pointer _ -> FreeUniverse
   | FnPtr _ -> FreeUniverse
-  | MonoTy _ -> err "Not applicable"
+  | MonoTy _ -> err "type_universe called with MonoTy argument"
 
 let is_numeric = function
   | Unit -> false
@@ -36,7 +36,7 @@ let is_numeric = function
   | Address _ -> false
   | Pointer _ -> false
   | FnPtr _ -> false
-  | MonoTy _ -> err "Not applicable"
+  | MonoTy _ -> err "is_numeric called with MonoTy argument"
 
 let is_comparable = function
   | Unit -> true
@@ -53,7 +53,7 @@ let is_comparable = function
   | Address _ -> true
   | Pointer _ -> true
   | FnPtr _ -> true
-  | MonoTy _ -> err "Not applicable"
+  | MonoTy _ -> err "is_comparable called with MonoTy argument"
 
 let rec type_variables = function
   | Unit ->

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -671,11 +671,14 @@ and cast_arguments (bindings: type_bindings) (params: value_parameter list) (arg
 
 and make_substs (bindings: type_bindings) (typarams: typarams): type_bindings =
   let f (tp: type_parameter): (type_parameter * ty) option =
-    match get_binding bindings tp with
-    | Some ty ->
-       Some (tp, ty)
-    | None ->
-       None
+    if (typaram_universe tp) = RegionUniverse then
+      Some (tp, RegionTy static_region)
+    else
+      match get_binding bindings tp with
+      | Some ty ->
+         Some (tp, ty)
+      | None ->
+         None
   in
   bindings_from_list (List.filter_map f (typarams_as_list typarams))
 

--- a/standard/Makefile
+++ b/standard/Makefile
@@ -19,7 +19,7 @@ TEST_BIN := test_bin
 all: $(TEST_BIN)
 
 $(TEST_BIN): src/*.aui src/*.aum test/*.aui test/*.aum
-	austral compile $(MODULES) --entrypoint=Standard.Test:Main --output=$(TEST_BIN)
+	../austral compile $(MODULES) --entrypoint=Standard.Test:Main --output=$(TEST_BIN)
 
 clean:
 	rm $(TEST_BIN)


### PR DESCRIPTION
The changes in #322 were wrong. The actual failure came up in the standard library. I merged before CI passed because CI is too slow and because it passed locally, but that was because the Makefile uses the globally installed `austral` binary instead of local, just-built one. I fixed the Makefile and the bugs.

Not entirely happy with how monomorphization works. I should clean it up in the future.