### PR TITLE
Use `internal_err` for ICEs instead of `err`

### DIFF
--- a/lib/AcmCode.ml
+++ b/lib/AcmCode.ml
@@ -17,18 +17,18 @@ let get_instance_ref (env: env) (id: decl_id): ins_ref =
           | Some (ModRec { name; _ }) ->
              InsRef { module_name=name; typeclass_name; argument }
           | _ ->
-             err "internal")
+            internal_err "Not in env")
       | _ ->
-         err "internal")
+        internal_err "Not in env")
   | _ ->
-     err "internal"
+     internal_err "Not in env"
 
 let get_method_ref (env: env) (id: ins_meth_id): ins_meth_ref =
   match get_instance_method env id with
   | Some (InsMethRec { instance_id; name; _ }) ->
      InsMethRef (get_instance_ref env instance_id, name)
   | None ->
-     err "internal: Not in env"
+     internal_err "Not in env"
 
 let get_func_ref (env: env) (id: decl_id): named_decl_ref =
   match get_decl_by_id env id with
@@ -40,7 +40,7 @@ let get_func_ref (env: env) (id: decl_id): named_decl_ref =
   | Some _ ->
      err "Not a function"
   | None ->
-     err "internal: Not in env"
+     internal_err "Not in env"
 
 let rec ser_expr (env: env) (expr: texpr): ser_expr =
   let se = ser_expr env in

--- a/lib/AcmSerialization.ml
+++ b/lib/AcmSerialization.ml
@@ -16,7 +16,7 @@ let par_mod_id_set (sexp: sexp): ModuleNameSet.t =
   | List atoms ->
      ModuleNameSet.of_list (List.map module_name_of_sexp atoms)
   | _ ->
-     err "internal: bad parse"
+    internal_err "bad parse"
 
 (* compiled_module *)
 
@@ -39,7 +39,7 @@ let par_compiled_module (sexp: sexp): compiled_module =
                   | List decls ->
                      List.map compiled_decl_of_sexp decls
                   | _ ->
-                    err "internal: bad parse");
+                    internal_err "bad parse");
        }
   | _ ->
-     err "internal: bad acm parse"
+     internal_err "bad acm parse"

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -145,7 +145,7 @@ let rec gen_type (ty: mono_ty): c_ty =
   | MonoFnPtr _ ->
      fn_type
   | MonoRegionTyVar _ ->
-     err "internal"
+     internal_err "Invalid C type"
 
 (* Expressions *)
 
@@ -155,7 +155,7 @@ let union_type_id = function
   | MonoNamedType id ->
      id
   | _ ->
-     err "Internal error: Union is not a named type?"
+     internal_err "Union is not a named type?"
 
 (* Given the ID of a union type, returns the name of the
    union's tag enum. *)
@@ -388,11 +388,11 @@ let get_original_module_name (env: env) (id: mono_id): module_name =
           | Some (ModRec { name; _ }) ->
              name
           | _ ->
-             err "Internal")
+             internal_err "Couldn't get module record")
       | _ ->
-         err "internal")
+         internal_err "Couldn't get function")
   | _ ->
-     err "internal"
+     internal_err "Couldn't get monomorph"
 
 let rec mono_desc (env: env) (id: mono_id): string =
   let mono = get_mono_or_die env id in
@@ -411,7 +411,7 @@ and get_mono_or_die (env: env) (id: mono_id): monomorph =
   | Some mono ->
      mono
   | None ->
-     err "internal"
+     internal_err "Couldn't get monomorph"
 
 and get_decl_name_or_die (env: env) (id: decl_id): string =
   match get_decl_by_id env id with
@@ -422,7 +422,7 @@ and get_decl_name_or_die (env: env) (id: decl_id): string =
       | None ->
          err "decl has no name")
   | None ->
-     err "internal"
+     internal_err "Couldn't find decl"
 
 and tyargs_string (args: mono_type_bindings): string =
   "["

--- a/lib/CombiningPass.ml
+++ b/lib/CombiningPass.ml
@@ -279,7 +279,7 @@ and parse_decl (module_name: module_name) (im: import_map) (bm: import_map) (cmb
           | None ->
              err "Interface declaration has no corresponding body declaration")
       | _ ->
-         err "Internal")
+         internal_err "Couldn't parse declaration declaration")
 
 and parse_defs (mn: module_name) (cmi: concrete_module_interface) (im: import_map) (defs: concrete_def list): combined_definition list =
   List.filter_map (parse_def mn cmi im) defs
@@ -304,7 +304,7 @@ and parse_def (module_name: module_name) (cmi: concrete_module_interface) (im: i
          else
            Some (private_def module_name im def)
       | _ ->
-         err "Internal")
+         internal_err "Couldn't parse definition")
 
 let as_public (def: combined_definition): combined_definition =
   match def with

--- a/lib/Env.ml
+++ b/lib/Env.ml
@@ -360,7 +360,7 @@ let rec store_function_body (env: env) (fn_id: decl_id) (body: tstmt): env =
                     | Some d ->
                        d
                     | _ ->
-                       err "Internal: No function with this ID.")
+                       internal_err ("No function with this ID: " ^ (show_decl_id fn_id)))
   in
   let new_decl: decl = replace_function_body decl body in
   let decls_without_existing_one: decl list = List.filter (fun (d: decl) -> not (equal_decl_id (decl_id d) fn_id)) decls in
@@ -372,11 +372,11 @@ and replace_function_body (decl: decl) (new_body: tstmt): decl =
   | Function { id; mod_id; vis; name; docstring; typarams; value_params; rt; external_name; body } ->
      (match body with
       | Some _ ->
-         err "Internal: function already has a body"
+         internal_err ("function `" ^ (ident_string name) ^ "` already has a body")
       | None ->
          Function { id; mod_id; vis; name; docstring; typarams; value_params; rt; external_name; body=(Some new_body) })
   | _ ->
-     err "Internal: not a function."
+     internal_err "not a function."
 
 let rec store_method_body (env: env) (ins_meth_id: ins_meth_id) (body: tstmt): env =
   let (Env { files; mods; methods; decls; monos; exports }) = env in
@@ -384,7 +384,7 @@ let rec store_method_body (env: env) (ins_meth_id: ins_meth_id) (body: tstmt): e
                               | Some m ->
                                  m
                               | _ ->
-                                 err "Internal: No instance method with this ID.")
+                                 internal_err ("No instance method with this ID " ^ (show_ins_meth_id ins_meth_id)))
   in
   let new_method: ins_meth_rec = replace_method_body meth body in
   let methods_without_existing_one: ins_meth_rec list = List.filter (fun (InsMethRec { id; _ }) -> not (equal_ins_meth_id id ins_meth_id)) methods in
@@ -395,7 +395,7 @@ and replace_method_body (meth: ins_meth_rec) (new_body: tstmt): ins_meth_rec =
   let (InsMethRec { id; instance_id; method_id; docstring; name; typarams; value_params; rt; body }) = meth in
   (match body with
    | Some _ ->
-      err "Internal: function already has a body"
+      internal_err ("function `" ^ (ident_string name) ^ "` already has a body")
    | None ->
       InsMethRec { id; instance_id; method_id; docstring; name; typarams; value_params; rt; body=(Some new_body) })
 
@@ -543,7 +543,7 @@ let pop_monomorph (env: env) (id: mono_id): (env * monomorph) =
     let env = Env { files; mods; methods; decls; monos = other_monos; exports } in
     (env, mono)
   | None ->
-    err "internal: monomorph with this ID does not exist"
+    internal_err ("monomorph with this ID does not exist: " ^ (show_mono_id id))
 
 let store_record_monomorph_definition (env: env) (id: mono_id) (new_slots: mono_slot list): env =
   let (env, mono) = pop_monomorph env id in
@@ -555,7 +555,7 @@ let store_record_monomorph_definition (env: env) (id: mono_id) (new_slots: mono_
     let env = Env { files; mods; methods; decls; monos = new_mono :: monos; exports } in
     env
   | _ ->
-    err "internal"
+    internal_err ("Couldn't find monomorph record definition with ID: " ^ (show_mono_id id))
 
 let store_union_monomorph_definition (env: env) (id: mono_id) (new_cases: mono_case list): env =
   let (env, mono) = pop_monomorph env id in
@@ -567,7 +567,7 @@ let store_union_monomorph_definition (env: env) (id: mono_id) (new_cases: mono_c
     let env = Env { files; mods; methods; decls; monos = new_mono :: monos; exports } in
     env
   | _ ->
-    err "internal"
+    internal_err ("Couldn't find monomorph union definition with ID: " ^ (show_mono_id id))
 
 let store_function_monomorph_definition (env: env) (id: mono_id) (new_body: mstmt): env =
   let (env, mono) = pop_monomorph env id in
@@ -579,7 +579,7 @@ let store_function_monomorph_definition (env: env) (id: mono_id) (new_body: mstm
     let env = Env { files; mods; methods; decls; monos = new_mono :: monos; exports } in
     env
   | _ ->
-    err "internal"
+    internal_err ("Couldn't find monomorph function definition with ID: " ^ (show_mono_id id))
 
 let store_instance_method_monomorph_definition (env: env) (id: mono_id) (new_body: mstmt): env =
   let (env, mono) = pop_monomorph env id in
@@ -591,7 +591,7 @@ let store_instance_method_monomorph_definition (env: env) (id: mono_id) (new_bod
     let env = Env { files; mods; methods; decls; monos = new_mono :: monos; exports } in
     env
   | _ ->
-    err "internal"
+    internal_err ("Couldn't find monomorph instance method definition with ID: " ^ (show_mono_id id))
 
 let get_instance_method (env: env) (target_id: ins_meth_id): ins_meth_rec option =
   let (Env { methods; _ }) = env in

--- a/lib/EnvExtras.ml
+++ b/lib/EnvExtras.ml
@@ -18,7 +18,9 @@ let get_decl_by_name_or_die (env: env) (name: sident): decl =
   match get_decl_by_name env name with
   | Some decl -> decl
   | None ->
-     internal_err "No declaration with name."
+     internal_err ("No declaration with name `"
+                   ^ ident_string (sident_name name)
+                   ^ "`.")
 
 let get_decl_sident_or_die (env: env) (id: decl_id): sident =
   match get_decl_by_id env id with
@@ -29,7 +31,9 @@ let get_decl_sident_or_die (env: env) (id: decl_id): sident =
       | None ->
          err "decl has no name")
   | None ->
-     err "internal"
+   internal_err ("decl with ID `" 
+                  ^ (show_decl_id id)
+                  ^ "` doesn't exist")
 
 let get_decl_name_or_die (env: env) (id: decl_id): string =
   match get_decl_by_id env id with
@@ -40,11 +44,17 @@ let get_decl_name_or_die (env: env) (id: decl_id): string =
       | None ->
          err "decl has no name")
   | None ->
-     err "internal"
+   internal_err ("decl with ID `" 
+                  ^ (show_decl_id id)
+                  ^ "` doesn't exist")
 
 let get_method_id_or_die (env: env) (typeclass_id: decl_id) (name: qident) =
   match get_method_from_typeclass_id_and_name env typeclass_id (original_name name) with
   | Some (TypeClassMethod { id; _ }) ->
      id
   | _ ->
-     internal_err "Could not retrieve method from the typeclass ID and the name."
+     internal_err ("Could not retrieve method from the typeclass ID `"
+                   ^ (show_decl_id typeclass_id)
+                   ^ "` and the name `"
+                   ^ (qident_debug_name name)
+                   ^ "`.")

--- a/lib/ExportInstantiation.ml
+++ b/lib/ExportInstantiation.ml
@@ -5,16 +5,17 @@ open MonoTypeBindings
 open Error
 open CodeGen
 open CRepr
+open Identifier
 
 (** Get the monomorph for an exported function. *)
 let get_export_monomorph (env: env) (id: decl_id): mono_id =
   match get_decl_by_id env id with
-  | Some (Function { id; _ }) ->
+  | Some (Function { id; name; _ }) ->
      (match get_function_monomorph env id empty_mono_bindings with
       | Some id ->
          id
       | _ ->
-         internal_err "No monomorph of this exported function.")
+         internal_err ("No monomorph of exported function `" ^ (ident_string name) ^ "`"))
   | _ ->
      internal_err "Can't find the exported fuction in the environment."
 

--- a/lib/ExtractionPass.ml
+++ b/lib/ExtractionPass.ml
@@ -105,7 +105,7 @@ let rec extract (env: env) (cmodule: combined_module) (interface_file: file_id o
       (List.map (fun mn ->
            match get_module_by_name env mn with
            | Some (ModRec { id; _ }) -> id
-           | None -> err "Internal")
+           | None -> internal_err ("Couldn't find module `" ^ (mod_name_string mn) ^ "`."))
          (List.of_seq (ModuleNameSet.to_seq module_names)))
   in
   (* Add the module to the environment. *)

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -33,7 +33,7 @@ let get_entry_or_fail (tbl: state_tbl) (name: identifier): (loop_depth * var_sta
   match get_entry tbl name with
   | Some p -> p
   | None ->
-     err ("Internal: variable `"
+     internal_err ("variable `"
           ^ (ident_string name)
           ^ "` not in state table. Table contents: \n\n"
           ^ (show_state_tbl tbl))

--- a/lib/Mtast.ml
+++ b/lib/Mtast.ml
@@ -175,7 +175,7 @@ let rec get_type (e: mexpr): mono_ty =
       | MonoWriteRef (t, _) ->
          t
       | _ ->
-         err ("Internal error: a dereference expression was constructed whose argument is not a reference type."))
+         internal_err ("a dereference expression was constructed whose argument is not a reference type."))
   | MTypecast (_, ty) ->
      ty
   | MSizeOf _ ->

--- a/lib/TastUtil.ml
+++ b/lib/TastUtil.ml
@@ -87,7 +87,7 @@ let rec get_type = function
       | WriteRef (t, _) ->
          t
       | _ ->
-         err ("Internal error: a dereference expression was constructed whose argument is not a reference type."))
+         internal_err ("a dereference expression was constructed whose argument is not a reference type."))
   | TSizeOf _ ->
      Integer (Unsigned, WidthByteSize)
   | TBorrowExpr (mode, _, region, ty) ->

--- a/lib/TypeMatch.ml
+++ b/lib/TypeMatch.ml
@@ -229,7 +229,7 @@ and get_instance (env: env) (source_module_name: module_name) (dispatch_ty: ty) 
       | [a] ->
          Some a
       | _::_ ->
-         internal_err "Multiple instances satisfy this call. This is an internal error in the compiler: the compiler should validate that there are no overlapping instances."
+         internal_err "Multiple instances satisfy this call. The compiler should validate that there are no overlapping instances."
       | [] ->
          None)
 

--- a/lib/TypeParser.ml
+++ b/lib/TypeParser.ml
@@ -153,7 +153,7 @@ let rec effective_universe name (typarams: typarams) declared_universe args =
   | LinearUniverse ->
      LinearUniverse
   | RegionUniverse ->
-     err "effective_universe called with a region type"
+     internal_err "effective_universe called with a region type"
   | TypeUniverse ->
      assert ((typarams_size typarams) > 0);
      if any_arg_is_linear args then

--- a/lib/TypeStripping.ml
+++ b/lib/TypeStripping.ml
@@ -26,7 +26,7 @@ let rec strip_type (ty: ty): stripped_ty =
   | Some ty ->
      ty
   | None ->
-     err "strip_type called with a region type as its argument"
+     internal_err "strip_type called with a region type as its argument"
 
 and strip_type' (ty: ty): stripped_ty option =
   match ty with
@@ -47,7 +47,7 @@ and strip_type' (ty: ty): stripped_ty option =
       | Some elem_ty ->
          Some (SStaticArray elem_ty)
       | None ->
-         err "Internal: array instantiated with a region type.")
+         internal_err "array instantiated with a region type.")
   | RegionTy r ->
      Some (SRegionTy r)
   | ReadRef (ty, r) ->
@@ -57,9 +57,9 @@ and strip_type' (ty: ty): stripped_ty option =
           | Some r ->
              Some (SReadRef (ty, r))
           | None ->
-             err "internal")
+             internal_err "unable to strip read ref type")
       | None ->
-         err "Internal: read ref instantiated with a region type.")
+         internal_err "read ref instantiated with a region type.")
   | WriteRef (ty, r) ->
      (match (strip_type' ty) with
       | Some ty ->
@@ -67,9 +67,9 @@ and strip_type' (ty: ty): stripped_ty option =
           | Some r ->
              Some (SWriteRef (ty, r))
           | None ->
-             err "internal")
+             internal_err "unable to strip write ref type")
       | None ->
-         err "Internal: write ref instantiated with a region type.")
+         internal_err "write ref instantiated with a region type.")
   | TyVar (TypeVariable (name, u, source, _)) ->
      if u = RegionUniverse then
        Some (SRegionTyVar (name, source))
@@ -85,18 +85,18 @@ and strip_type' (ty: ty): stripped_ty option =
       | Some ty ->
          Some (SAddress ty)
       | None ->
-         err "Internal: Address type instantiated with a region type.")
+         internal_err "Address type instantiated with a region type.")
   | Pointer ty ->
      (match (strip_type' ty) with
       | Some ty ->
          Some (SPointer ty)
       | None ->
-         err "Internal: Pointer type instantiated with a region type.")
+         internal_err "Pointer type instantiated with a region type.")
   | FnPtr (args, rt) ->
      let rt =
        (match strip_type' rt with
         | Some ty -> ty
-        | _ -> err "internal")
+        | _ -> internal_err "Function pointer type instantiated with a region type.")
      in
      Some (SFnPtr (List.filter_map strip_type' args, rt))
   | MonoTy id ->


### PR DESCRIPTION
Replace uses for `err` for errors that are internal compiler errors. Some ICEs also contain additional diagnostics now.

This is my first time working in OCaml so best practices might not have been followed. Please let me know if there are any corrections I should make.

This fixes a part of #256.