### PR TITLE
Fix unescaped quotes in rendered C

### DIFF
--- a/editor/vscode-austral/.vscode/launch.json
+++ b/editor/vscode-austral/.vscode/launch.json
@@ -1,0 +1,17 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/editor/vscode-austral/.vscodeignore
+++ b/editor/vscode-austral/.vscodeignore
@@ -1,0 +1,4 @@
+.vscode/**
+.vscode-test/**
+.gitignore
+vsc-extension-quickstart.md

--- a/editor/vscode-austral/CHANGELOG.md
+++ b/editor/vscode-austral/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to the "austral" extension will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## [Unreleased]
+
+- Initial release

--- a/editor/vscode-austral/README.md
+++ b/editor/vscode-austral/README.md
@@ -1,0 +1,65 @@
+# austral README
+
+This is the README for your extension "austral". After writing up a brief description, we recommend including the following sections.
+
+## Features
+
+Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
+
+For example if there is an image subfolder under your extension project workspace:
+
+\!\[feature X\]\(images/feature-x.png\)
+
+> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
+
+## Requirements
+
+If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+
+## Extension Settings
+
+Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
+
+For example:
+
+This extension contributes the following settings:
+
+* `myExtension.enable`: Enable/disable this extension.
+* `myExtension.thing`: Set to `blah` to do something.
+
+## Known Issues
+
+Calling out known issues can help limit users opening duplicate issues against your extension.
+
+## Release Notes
+
+Users appreciate release notes as you update your extension.
+
+### 1.0.0
+
+Initial release of ...
+
+### 1.0.1
+
+Fixed issue #.
+
+### 1.1.0
+
+Added features X, Y, and Z.
+
+---
+
+## Working with Markdown
+
+You can author your README using Visual Studio Code. Here are some useful editor keyboard shortcuts:
+
+* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux).
+* Toggle preview (`Shift+Cmd+V` on macOS or `Shift+Ctrl+V` on Windows and Linux).
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets.
+
+## For more information
+
+* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
+* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
+
+**Enjoy!**

--- a/editor/vscode-austral/language-configuration.json
+++ b/editor/vscode-austral/language-configuration.json
@@ -1,0 +1,30 @@
+{
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "//",
+        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+        "blockComment": [ "/*", "*/" ]
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    // symbols that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/editor/vscode-austral/package.json
+++ b/editor/vscode-austral/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "austral",
+  "displayName": "austral",
+  "description": "Austral language support for VS Code",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.74.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [{
+      "id": "austral",
+      "aliases": ["Austral", "austral"],
+      "extensions": [".aum",".aui"],
+      "configuration": "./language-configuration.json"
+    }],
+    "grammars": [{
+      "language": "austral",
+      "scopeName": "source.austral",
+      "path": "./syntaxes/austral.tmLanguage.json"
+    }]
+  }
+}

--- a/editor/vscode-austral/syntaxes/austral.tmLanguage.json
+++ b/editor/vscode-austral/syntaxes/austral.tmLanguage.json
@@ -7,6 +7,9 @@
 		},
 		{
 			"include": "#strings"
+		},
+		{
+			"include": "#triplestrings"
 		}
 	],
 	"repository": {
@@ -26,6 +29,17 @@
 			"name": "string.quoted.double.austral",
 			"begin": "\"",
 			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.austral",
+					"match": "\\\\."
+				}
+			]
+		},
+		"triplestrings": {
+			"name": "string.quoted.triple.austral",
+			"begin": "\"\"\"",
+			"end": "\"\"\"",
 			"patterns": [
 				{
 					"name": "constant.character.escape.austral",

--- a/editor/vscode-austral/syntaxes/austral.tmLanguage.json
+++ b/editor/vscode-austral/syntaxes/austral.tmLanguage.json
@@ -1,0 +1,38 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Austral",
+	"patterns": [
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#strings"
+		}
+	],
+	"repository": {
+		"keywords": {
+			"patterns": [
+				{
+					"name": "keyword.control.austral",
+					"match": "\\b(if|case|while|for|return)\\b"
+				},
+				{
+					"name": "keyword.other.austral",
+					"match": "\\b(end\\s+if|end\\s+case|end\\s+while|end\\s+for|end|from|to|do|of|let|then|else|else\\s+if|is|module\\s+body|end\\s+module\\s+body|module|end\\s+module|generic|method|function|instance|pragma|constant|record|union|typeclass|import|when)\\b"
+				}
+			]
+		},
+		"strings": {
+			"name": "string.quoted.double.austral",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.austral",
+					"match": "\\\\."
+				}
+			]
+		}
+	},
+	"scopeName": "source.austral"
+}

--- a/editor/vscode-austral/vsc-extension-quickstart.md
+++ b/editor/vscode-austral/vsc-extension-quickstart.md
@@ -1,0 +1,29 @@
+# Welcome to your VS Code Extension
+
+## What's in the folder
+
+* This folder contains all of the files necessary for your extension.
+* `package.json` - this is the manifest file in which you declare your language support and define the location of the grammar file that has been copied into your extension.
+* `syntaxes/austral.tmLanguage.json` - this is the Text mate grammar file that is used for tokenization.
+* `language-configuration.json` - this is the language configuration, defining the tokens that are used for comments and brackets.
+
+## Get up and running straight away
+
+* Make sure the language configuration settings in `language-configuration.json` are accurate.
+* Press `F5` to open a new window with your extension loaded.
+* Create a new file with a file name suffix matching your language.
+* Verify that syntax highlighting works and that the language configuration settings are working.
+
+## Make changes
+
+* You can relaunch the extension from the debug toolbar after making changes to the files listed above.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
+
+## Add more language features
+
+* To add features such as IntelliSense, hovers and validators check out the VS Code extenders documentation at https://code.visualstudio.com/docs
+
+## Install your extension
+
+* To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
+* To share your extension with the world, read on https://code.visualstudio.com/docs about publishing an extension.

--- a/lib/Escape.ml
+++ b/lib/Escape.ml
@@ -15,6 +15,8 @@ and escape_list lst =
   | ('\\' :: 'r' :: rest) -> '\r' :: (escape_list rest)
   | ('\\' :: 't' :: rest) -> '\t' :: (escape_list rest)
   | ('\\' :: '\'' :: rest) -> '\'' :: (escape_list rest)
+  | ('\\' :: '"' :: '"' :: '"' :: rest) -> '"' :: '"' :: '"' :: (escape_list rest)
+  | ('\\' :: '"' :: rest) -> '"' :: (escape_list rest)
   | ('\\' :: '\\' :: rest) -> '\\' :: (escape_list rest)
   | ('\\' :: ' ' :: rest) -> consume_whitespace (' ' :: rest)
   | ('\\' :: '\n' :: rest) -> consume_whitespace (' ' :: rest)
@@ -44,4 +46,5 @@ and unescape_char = function
   | '\t' -> "\\t"
   | '\'' -> "\\\'"
   | '\\' -> "\\\\"
+  | '"' -> "\\\""
   | c -> String.make 1 c

--- a/lib/Escape.ml
+++ b/lib/Escape.ml
@@ -15,7 +15,6 @@ and escape_list lst =
   | ('\\' :: 'r' :: rest) -> '\r' :: (escape_list rest)
   | ('\\' :: 't' :: rest) -> '\t' :: (escape_list rest)
   | ('\\' :: '\'' :: rest) -> '\'' :: (escape_list rest)
-  | ('\\' :: '"' :: '"' :: '"' :: rest) -> '"' :: '"' :: '"' :: (escape_list rest)
   | ('\\' :: '"' :: rest) -> '"' :: (escape_list rest)
   | ('\\' :: '\\' :: rest) -> '\\' :: (escape_list rest)
   | ('\\' :: ' ' :: rest) -> consume_whitespace (' ' :: rest)

--- a/test/CRendererTest.ml
+++ b/test/CRendererTest.ml
@@ -9,7 +9,8 @@ let test_render_bool _ =
 
 let test_render_string _ =
   assert_equal (r_e (CString  (escape_string "abcd"))) "\"abcd\"";
-  assert_equal (r_e (CString (escape_string "\""))) "\"\\\"\""
+  assert_equal (r_e (CString (escape_string "\""))) "\"\\\"\"";
+  assert_equal (r_e (CString (escape_string "\"\"\""))) "\"\\\"\\\"\\\"\""
   
   
   let suite =

--- a/test/CRendererTest.ml
+++ b/test/CRendererTest.ml
@@ -1,0 +1,22 @@
+open OUnit2
+open Austral_core.CRenderer
+open Austral_core.Escape
+
+let r_e = render_expr
+let test_render_bool _ =
+  assert_equal (r_e (CBool true)) "true";
+  assert_equal (r_e (CBool false)) "false"
+
+let test_render_string _ =
+  assert_equal (r_e (CString  (escape_string "abcd"))) "\"abcd\"";
+  assert_equal (r_e (CString (escape_string "\""))) "\"\\\"\""
+  
+  
+  let suite =
+    "CliUtil" >::: [
+        "render_bool" >:: test_render_bool;
+        "render_string" >:: test_render_string
+      ]
+  
+  let _ = run_test_tt_main suite
+  

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,8 @@
 (tests
- (names ExpressionParserTest UtilTest CliUtilTest CliParserTest)
+ (names
+  ExpressionParserTest
+  UtilTest
+  CliUtilTest
+  CliParserTest
+  CRendererTest)
  (libraries austral_core ounit2))


### PR DESCRIPTION
Escaped quotes and triple quotes weren't handled by the `Escape` module, so they would make their way into the C output. This fix adds  `\"` to `Escape.escape_list`, and `"` to `Escape.unescape_char`.

I also started on a unit test for `CRenderer`. Right now it's woefully incomplete, it just tests this behavior specifically.