### PR TITLE
Fix unescaped quotes in C output

### DIFF
--- a/lib/Escape.ml
+++ b/lib/Escape.ml
@@ -15,6 +15,8 @@ and escape_list lst =
   | ('\\' :: 'r' :: rest) -> '\r' :: (escape_list rest)
   | ('\\' :: 't' :: rest) -> '\t' :: (escape_list rest)
   | ('\\' :: '\'' :: rest) -> '\'' :: (escape_list rest)
+  | ('\\' :: '"' :: '"' :: '"' :: rest) -> '"' :: '"' :: '"' :: (escape_list rest)
+  | ('\\' :: '"' :: rest) -> '"' :: (escape_list rest)
   | ('\\' :: '\\' :: rest) -> '\\' :: (escape_list rest)
   | ('\\' :: ' ' :: rest) -> consume_whitespace (' ' :: rest)
   | ('\\' :: '\n' :: rest) -> consume_whitespace (' ' :: rest)
@@ -44,4 +46,5 @@ and unescape_char = function
   | '\t' -> "\\t"
   | '\'' -> "\\\'"
   | '\\' -> "\\\\"
+  | '"' -> "\\\""
   | c -> String.make 1 c

--- a/lib/Escape.ml
+++ b/lib/Escape.ml
@@ -15,7 +15,6 @@ and escape_list lst =
   | ('\\' :: 'r' :: rest) -> '\r' :: (escape_list rest)
   | ('\\' :: 't' :: rest) -> '\t' :: (escape_list rest)
   | ('\\' :: '\'' :: rest) -> '\'' :: (escape_list rest)
-  | ('\\' :: '"' :: '"' :: '"' :: rest) -> '"' :: '"' :: '"' :: (escape_list rest)
   | ('\\' :: '"' :: rest) -> '"' :: (escape_list rest)
   | ('\\' :: '\\' :: rest) -> '\\' :: (escape_list rest)
   | ('\\' :: ' ' :: rest) -> consume_whitespace (' ' :: rest)

--- a/test/CRendererTest.ml
+++ b/test/CRendererTest.ml
@@ -9,7 +9,8 @@ let test_render_bool _ =
 
 let test_render_string _ =
   assert_equal (r_e (CString  (escape_string "abcd"))) "\"abcd\"";
-  assert_equal (r_e (CString (escape_string "\""))) "\"\\\"\""
+  assert_equal (r_e (CString (escape_string "\""))) "\"\\\"\"";
+  assert_equal (r_e (CString (escape_string "\"\"\""))) "\"\\\"\\\"\\\"\""
   
   
   let suite =

--- a/test/CRendererTest.ml
+++ b/test/CRendererTest.ml
@@ -1,0 +1,22 @@
+open OUnit2
+open Austral_core.CRenderer
+open Austral_core.Escape
+
+let r_e = render_expr
+let test_render_bool _ =
+  assert_equal (r_e (CBool true)) "true";
+  assert_equal (r_e (CBool false)) "false"
+
+let test_render_string _ =
+  assert_equal (r_e (CString  (escape_string "abcd"))) "\"abcd\"";
+  assert_equal (r_e (CString (escape_string "\""))) "\"\\\"\""
+  
+  
+  let suite =
+    "CliUtil" >::: [
+        "render_bool" >:: test_render_bool;
+        "render_string" >:: test_render_string
+      ]
+  
+  let _ = run_test_tt_main suite
+  

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,8 @@
 (tests
- (names ExpressionParserTest UtilTest CliUtilTest CliParserTest)
+ (names
+  ExpressionParserTest
+  UtilTest
+  CliUtilTest
+  CliParserTest
+  CRendererTest)
  (libraries austral_core ounit2))


### PR DESCRIPTION
Escaped quotes and triple quotes weren't handled by the `Escape` module, so they would make their way into the C output. This fix adds  `\"` to `Escape.escape_list`, and `"` to `Escape.unescape_char`.

I also started on a unit test for `CRenderer`. Right now it's woefully incomplete, it just tests this behavior specifically.