### PR TITLE
Fix parse failure on "else if" (#364)

### DIFF
--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -97,6 +97,7 @@ rule token = parse
   | "instance" { INSTANCE }
   | "method" { METHOD }
   | "if" { IF }
+  | "else" whitespace+ "if" { ELSE_IF }
   | "then" { THEN }
   | "else" { ELSE }
   | "let" { LET }

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -56,6 +56,7 @@ open Span
 %token IF
 %token THEN
 %token ELSE
+%token ELSE_IF
 %token LET
 %token WHILE
 %token FOR
@@ -310,7 +311,7 @@ if_statement:
   ;
 
 else_clause:
-  | ELSE IF expression THEN block else_clause { CIf (from_loc $loc, $3, $5, $6) }
+  | ELSE_IF expression THEN block else_clause { CIf (from_loc $loc, $2, $4, $5) }
   | ELSE block END IF SEMI { $2 }
   | END IF SEMI { CSkip (from_loc $loc) }
   ;

--- a/test-programs/suites/001-trivial/012-else-if/README.md
+++ b/test-programs/suites/001-trivial/012-else-if/README.md
@@ -1,0 +1,1 @@
+Test of a else if.

--- a/test-programs/suites/001-trivial/012-else-if/Test.aum
+++ b/test-programs/suites/001-trivial/012-else-if/Test.aum
@@ -1,0 +1,16 @@
+module body Test is
+    function main(): ExitCode is
+        printLn("Start");
+        for i from 0 to 2 do
+            if i = 0 then
+                printLn("0");
+            else if i = 1 then
+                printLn("1");
+            else
+                printLn("Not 0 or 1");
+            end if;
+        end for;
+        printLn("End");
+        return ExitSuccess();
+    end;
+end module body.

--- a/test-programs/suites/001-trivial/012-else-if/program-stdout.txt
+++ b/test-programs/suites/001-trivial/012-else-if/program-stdout.txt
@@ -1,0 +1,5 @@
+Start
+0
+1
+Not 0 or 1
+End


### PR DESCRIPTION
Fix "else if" failing to parse (#364). The issue seemed to be the `ELSE` (no `IF`) option matching first, since the parser wouldn't look ahead. This fix adds a new `else[whitespace]if` token, so the parser won't need to look ahead.
