### PR TITLE
Fix resizeArray return type

### DIFF
--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -1116,7 +1116,10 @@ and get_union_type_definition (importing_module: module_name) (env: env) (ty: ty
                       | NamedType (n, _, _) ->
                          n
                       | _ ->
-                         err "Not a named type") in
+                         austral_raise GenericError [
+                             Text "Case statement: case expression type is not a naed typeNot a union type:";
+                             Code (type_string ty)
+                           ]) in
   match get_decl_by_name env (qident_to_sident name) with
   | Some (Union { id; vis; name; mod_id; typarams; universe; _ }) ->
      let module_name = module_name_from_id env mod_id in

--- a/lib/builtin/Memory.aui
+++ b/lib/builtin/Memory.aui
@@ -30,7 +30,7 @@ module Austral.Memory is
     function loadWrite(ref: &![Pointer[T], R]): &![T, R];
 
     generic [T: Type]
-    function resizeArray(array: Pointer[T], size: Index): Pointer[T];
+    function resizeArray(array: Pointer[T], size: Index): Address[T];
 
     generic [T: Type, U: Type]
     function memmove(source: Pointer[T], destination: Pointer[U], count: ByteSize): Unit;

--- a/lib/builtin/Memory.aum
+++ b/lib/builtin/Memory.aum
@@ -66,9 +66,9 @@ module body Austral.Memory is
     end;
 
     generic [T: Type]
-    function resizeArray(array: Pointer[T], size: Index): Pointer[T] is
+    function resizeArray(array: Pointer[T], size: Index): Address[T] is
         let total: Index := sizeToIndex(sizeof(T)) * size;
-        return @embed(Pointer[T], "au_realloc($1, $2)", array, total);
+        return @embed(Address[T], "au_realloc($1, $2)", array, total);
     end;
 
     generic [T: Type, U: Type]

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -239,16 +239,21 @@ module body Standard.Buffer is
     generic [T: Type, R: Region]
     function bump(buf: &![Buffer[T], R]): Unit is
         let new_capacity: Index := (!buf->capacity) * 2;
-        let new_array: Pointer[T] := resizeArray(!buf->array, new_capacity);
-        memcpy(
-            destination => new_array,
-            source => !buf->array,
-            count => arraySizeInBytes(sizeof(T), !buf->size)
-        );
-        buf->capacity := new_capacity;
-        buf->array := new_array;
-        -- invariants(buf : &[Buffer[T], R]);
-        return nil;
+        let new_addr: Address[T] := resizeArray(!buf->array, new_capacity);
+        case nullCheck(new_addr) of
+            when Some(value as new_array: Pointer[T]) do
+                memcpy(
+                    destination => new_array,
+                    source => !buf->array,
+                    count => arraySizeInBytes(sizeof(T), !buf->size)
+                );
+                buf->capacity := new_capacity;
+                buf->array := new_array;
+                -- invariants(buf : &[Buffer[T], R]);
+                return nil;
+            when None do
+                abort("bump: allocation failed");
+         end case;
     end;
 
     generic [T: Type, R: Region]


### PR DESCRIPTION
Should return `Address[T]` rather than `Pointer[T]` since it can be null.

Fixes #350 