### PR TITLE
Fix: linearity checker confused by renaming in record destructuring

### DIFF
--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -297,18 +297,18 @@ and check_stmt (tbl: state_tbl) (depth: loop_depth) (stmt: tstmt): state_tbl =
      (* Iterate over the bidings, for each that is linear, add an entry to the
         table. Also, keep track of the names of the linear variables. *)
      let linear_names: identifier list =
-       List.filter_map (fun (TypedBinding { name; ty; _ }) ->
+       List.filter_map (fun (TypedBinding { rename; ty; _ }) ->
            if universe_linear_ish (type_universe ty) then
-             Some name
+             Some rename
            else
              None)
          bindings
      in
      let tbl: state_tbl =
        Util.iter_with_context
-         (fun tbl (TypedBinding { name; ty; _ }) ->
+         (fun tbl (TypedBinding { rename; ty; _ }) ->
            if universe_linear_ish (type_universe ty) then
-             add_entry tbl name depth
+             add_entry tbl rename depth
            else
              tbl)
          tbl

--- a/test-programs/suites/011-bugs/github-373/README.md
+++ b/test-programs/suites/011-bugs/github-373/README.md
@@ -1,0 +1,1 @@
+Regression test for [GitHub issue #373](https://github.com/austral/austral/issues/373).

--- a/test-programs/suites/011-bugs/github-373/Test.aum
+++ b/test-programs/suites/011-bugs/github-373/Test.aum
@@ -1,0 +1,15 @@
+module body Test is
+    record B : Linear is
+        x : Int32;
+    end;
+    record A : Linear is
+        b: B;
+    end;
+
+    function main(): ExitCode is
+        let a: A := A(b => B(x => 5));
+        let { b as b1: B } := a;
+        let { x as x1: Int32 } := b1;
+        return ExitSuccess();
+    end;
+end module body.


### PR DESCRIPTION
Fix #373 