### PR TITLE
Fix: generated C code doesn't compile when defining a constant with a record type

### DIFF
--- a/lib/CRenderer.ml
+++ b/lib/CRenderer.ml
@@ -28,6 +28,11 @@ let rec render_unit (CUnit (name, decls)): string =
 
 and render_decl i d =
   match d with
+  | CMacro (desc, name, value) ->
+     [
+       Line (i, desc_text desc);
+       Line (i, "#define " ^ name ^ " " ^ (e value))
+     ]
   | CConstantDefinition (desc, name, ty, value) ->
      [
        Line (i, desc_text desc);

--- a/lib/CRepr.ml
+++ b/lib/CRepr.ml
@@ -62,6 +62,7 @@ and c_switch_case =
 type desc = Desc of string
 
 type c_decl =
+  | CMacro of desc * string * c_expr
   | CConstantDefinition of desc * string * c_ty * c_expr
   | CStructForwardDeclaration of desc * string
   | CTypeDefinition of desc * string * c_ty

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -432,10 +432,11 @@ and render_mono (env: env) (id: decl_id) (tyargs: mono_type_bindings): string =
 
 let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
   match decl with
-  | MConstant (_, n, ty, e) ->
+  | MConstant (_, n, _, e) ->
      let d = Desc "Constant" in
      [
-       CConstantDefinition (d, gen_sident mn n, gen_type ty, gen_exp mn e)
+       (* CConstantDefinition (d, gen_sident mn n, gen_type ty, gen_exp mn e) *)
+       CMacro (d, gen_sident mn n, gen_exp mn e)
      ]
   | MRecord _ ->
      []
@@ -609,6 +610,8 @@ let decl_order = function
   | CTypeDefinition _ ->
      4
   | CConstantDefinition _ ->
+     5
+  | CMacro _ ->
      5
   | CFunctionDeclaration _ ->
      6

--- a/test-programs/suites/011-bugs/github-375/README.md
+++ b/test-programs/suites/011-bugs/github-375/README.md
@@ -1,0 +1,1 @@
+Regression test for [GitHub issue #375](https://github.com/austral/austral/issues/375).

--- a/test-programs/suites/011-bugs/github-375/Test.aum
+++ b/test-programs/suites/011-bugs/github-375/Test.aum
@@ -1,0 +1,13 @@
+module body Test is
+    record R: Free is
+        x: Nat32;
+    end;
+
+    constant one: Nat32 := 1;
+
+    constant r_one: R := R(x => one);
+
+    function main(): ExitCode is
+        return ExitSuccess();
+    end;
+end module body.


### PR DESCRIPTION
Because struct initializers for global variables are not portable C.

Fixes #375 