### PR TITLE
Extend the Buffer API

### DIFF
--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -143,6 +143,9 @@ module Standard.Buffer is
     generic [T: Type, R: Region]
     function remove(buf: &![Buffer[T], R], pos: Index): T;
 
+    """
+    Remove the first element from the buffer and return it.
+    """
     generic [T: Type, R: Region]
     function removeFirst(buf: &![Buffer[T], R]): T;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -110,13 +110,18 @@ module Standard.Buffer is
     ---
 
     """
-    Insert an element into the buffer in the given position.
+    Insert an element into the buffer in the given position, resizing if
+    needed. Aborts on allocation failure.
 
     Range for `pos` is from 0 to the length of the buffer.
     """
     generic [T: Type, R: Region]
     function insert(buf: &![Buffer[T], R], pos: Index, element: T): Unit;
 
+    """
+    Insert the given element at the zeroth position of the buffer, pushing
+    everything to the right.
+    """
     generic [T: Type, R: Region]
     function insertFront(buf: &![Buffer[T], R], element: T): Unit;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -137,4 +137,7 @@ module Standard.Buffer is
 
     generic [T: Type, R: Region]
     function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit;
+
+    generic [T: Type, U: Type]
+    function map(buf: Buffer[T], fn: Fn[T, U]): Buffer[U];
 end module.

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -109,6 +109,11 @@ module Standard.Buffer is
     --- Insertion
     ---
 
+    """
+    Insert an element into the buffer in the given position.
+
+    Range for `pos` is from 0 to the length of the buffer.
+    """
     generic [T: Type, R: Region]
     function insert(buf: &![Buffer[T], R], pos: Index, element: T): Unit;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -120,11 +120,16 @@ module Standard.Buffer is
 
     """
     Insert the given element at the zeroth position of the buffer, pushing
-    everything to the right.
+    everything to the right and resizing if needed. Aborts on allocation
+    failure.
     """
     generic [T: Type, R: Region]
     function insertFront(buf: &![Buffer[T], R], element: T): Unit;
 
+    """
+    Insert the given element at the end of the buffer and resizing if needed.
+    Aborts on allocation failure.
+    """
     generic [T: Type, R: Region]
     function insertBack(buf: &![Buffer[T], R], element: T): Unit;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -149,6 +149,9 @@ module Standard.Buffer is
     generic [T: Type, R: Region]
     function removeFirst(buf: &![Buffer[T], R]): T;
 
+    """
+    Remove the last element from the buffer and return it.
+    """
     generic [T: Type, R: Region]
     function removeLast(buf: &![Buffer[T], R]): T;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -159,6 +159,9 @@ module Standard.Buffer is
     --- Reversal
     ---
 
+    """
+    Reverse the buffer in place.
+    """
     generic [T: Type, R: Region]
     function reverse(buf: &![Buffer[T], R]): Unit;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -130,4 +130,11 @@ module Standard.Buffer is
 
     generic [T: Type, R: Region]
     function reverse(buf: &![Buffer[T], R]): Unit;
+
+    ---
+    --- Map
+    ---
+
+    generic [T: Type, R: Region]
+    function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit;
 end module.

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -169,6 +169,11 @@ module Standard.Buffer is
     --- Map
     ---
 
+    """
+    Iterate over each element in the buffer, transforming it through `fn`, and
+    store the result in place. Like `swapTransform` applied to the whole
+    buffer.
+    """
     generic [T: Type, R: Region]
     function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -177,6 +177,11 @@ module Standard.Buffer is
     generic [T: Type, R: Region]
     function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit;
 
+    """
+    Consumes the buffer and returns a new buffer of the same length, whose
+    elements are the result of applying `fn` to the element from `buf` with the
+    same index.
+    """
     generic [T: Type, U: Type]
     function map(buf: Buffer[T], fn: Fn[T, U]): Buffer[U];
 end module.

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -92,6 +92,10 @@ module Standard.Buffer is
     generic [T: Type, R: Region]
     function swapIndex(buf: &![Buffer[T], R], a: Index, b: Index): Unit;
 
+    """
+    Take the element at `pos`, transform it through `fn`, and store the result
+    in place.
+    """
     generic [T: Type, R: Region]
     function swapTransform(buf: &![Buffer[T], R], pos: Index, fn: Fn[T, T]): Unit;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -137,6 +137,9 @@ module Standard.Buffer is
     --- Removal
     ---
 
+    """
+    Remove the element from the given position in the buffer, and return it.
+    """
     generic [T: Type, R: Region]
     function remove(buf: &![Buffer[T], R], pos: Index): T;
 

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -89,6 +89,9 @@ module Standard.Buffer is
     generic [T: Type, R: Region]
     function swapIndex(buf: &![Buffer[T], R], a: Index, b: Index): Unit;
 
+    generic [T: Type, R: Region]
+    function swapTransform(buf: &![Buffer[T], R], pos: Index, fn: Fn[T, T]): Unit;
+
     """
     Store `element` in every position of `buf`.
     """

--- a/standard/src/Buffer.aui
+++ b/standard/src/Buffer.aui
@@ -86,6 +86,9 @@ module Standard.Buffer is
     generic [T: Type, R: Region]
     function swapNth(buf: &![Buffer[T], R], pos: Index, element: T): T;
 
+    """
+    Swap two elements in the given buffer by their indices.
+    """
     generic [T: Type, R: Region]
     function swapIndex(buf: &![Buffer[T], R], a: Index, b: Index): Unit;
 

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -144,6 +144,19 @@ module body Standard.Buffer is
         return nil;
     end;
 
+    """
+    Deallocates a non-empty, potentially linear array. This is for internal use
+    _only_. The assumption here is that the elements have already been safely
+    extracted somewhere so linearity is preserved. See the implementation of
+    for an example.
+    """
+    generic [T: Type]
+    function destroyUnsafe(buffer: Buffer[T]): Unit is
+        let { capacity: Index, size: Index, array: Pointer[T] } := buffer;
+        deallocate(array);
+        return nil;
+    end;
+
     ---
     --- Retrieve
     ---
@@ -350,6 +363,7 @@ module body Standard.Buffer is
     function removeLast(buf: &![Buffer[T], R]): T is
         return remove(buf, (!buf->size) - 1);
     end;
+
     ---
     --- Reversal
     ---
@@ -422,5 +436,26 @@ module body Standard.Buffer is
             swapTransform(buf, i, fn);
         end for;
         return nil;
+    end;
+
+    generic [T: Type, U: Type]
+    function map(buf: Buffer[T], fn: Fn[T, U]): Buffer[U] is
+        let newbuf: Buffer[U] := allocateEmpty();
+        -- Iterate over everything in the buffer, transforming it and moving it
+        -- to the new buffer.
+        for i from 0 to (buf.size) - 1 do
+            -- Load the element at `pos`.
+            let ptr: Pointer[T] := positiveOffset(buf.array, i);
+            let old: T := load(ptr);
+            -- Transform it.
+            let new: U := fn(old);
+            -- Store the transformed version in the new buffer.
+            insertBack(&!newbuf, new);
+        end for;
+        -- Deallocate the old array. Every element has been transformed and
+        -- copied over, so this is safe.
+        destroyUnsafe(buf);
+        -- Return the new buffer.
+        return newbuf;
     end;
 end module body.

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -161,9 +161,6 @@ module body Standard.Buffer is
     --- Retrieve
     ---
 
-    """
-    Return the length of the buffer.
-    """
     generic [T: Type, R: Region]
     function length(buf: &[Buffer[T], R]): Index is
         return !buf->size;

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -412,4 +412,15 @@ module body Standard.Buffer is
         return nil;
     end;
 
+    ---
+    --- Map
+    ---
+
+    generic [T: Type, R: Region]
+    function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit is
+        for i from 0 to (!buf->size) - 1 do
+            swapTransform(buf, i, fn);
+        end for;
+        return nil;
+    end;
 end module body.

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -381,6 +381,39 @@ module body Standard.Buffer is
     end;
 
     ---
+    --- Map
+    ---
+
+    generic [T: Type, R: Region]
+    function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit is
+        for i from 0 to (!buf->size) - 1 do
+            swapTransform(buf, i, fn);
+        end for;
+        return nil;
+    end;
+
+    generic [T: Type, U: Type]
+    function map(buf: Buffer[T], fn: Fn[T, U]): Buffer[U] is
+        let newbuf: Buffer[U] := allocateEmpty();
+        -- Iterate over everything in the buffer, transforming it and moving it
+        -- to the new buffer.
+        for i from 0 to (buf.size) - 1 do
+            -- Load the element at `pos`.
+            let ptr: Pointer[T] := positiveOffset(buf.array, i);
+            let old: T := load(ptr);
+            -- Transform it.
+            let new: U := fn(old);
+            -- Store the transformed version in the new buffer.
+            insertBack(&!newbuf, new);
+        end for;
+        -- Deallocate the old array. Every element has been transformed and
+        -- copied over, so this is safe.
+        destroyUnsafe(buf);
+        -- Return the new buffer.
+        return newbuf;
+    end;
+
+    ---
     --- Utilities
     ---
 
@@ -424,38 +457,5 @@ module body Standard.Buffer is
             count => chunk_size
         );
         return nil;
-    end;
-
-    ---
-    --- Map
-    ---
-
-    generic [T: Type, R: Region]
-    function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit is
-        for i from 0 to (!buf->size) - 1 do
-            swapTransform(buf, i, fn);
-        end for;
-        return nil;
-    end;
-
-    generic [T: Type, U: Type]
-    function map(buf: Buffer[T], fn: Fn[T, U]): Buffer[U] is
-        let newbuf: Buffer[U] := allocateEmpty();
-        -- Iterate over everything in the buffer, transforming it and moving it
-        -- to the new buffer.
-        for i from 0 to (buf.size) - 1 do
-            -- Load the element at `pos`.
-            let ptr: Pointer[T] := positiveOffset(buf.array, i);
-            let old: T := load(ptr);
-            -- Transform it.
-            let new: U := fn(old);
-            -- Store the transformed version in the new buffer.
-            insertBack(&!newbuf, new);
-        end for;
-        -- Deallocate the old array. Every element has been transformed and
-        -- copied over, so this is safe.
-        destroyUnsafe(buf);
-        -- Return the new buffer.
-        return newbuf;
     end;
 end module body.

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -180,9 +180,6 @@ module body Standard.Buffer is
     --- Update
     ---
 
-    """
-    Store `element` in the given position of `buf`.
-    """
     generic [T: Free, R: Region]
     function storeNth(buf: &![Buffer[T], R], pos: Index, element: T): Unit is
         if pos >= (!buf->size) then

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -218,6 +218,22 @@ module body Standard.Buffer is
         return nil;
     end;
 
+    generic [T: Type, R: Region]
+    function swapTransform(buf: &![Buffer[T], R], pos: Index, fn: Fn[T, T]): Unit is
+        if pos >= (!buf->size) then
+            abort("swapTransform: index out of range");
+        end if;
+        -- Load the element at `pos`.
+        let ptr: Pointer[T] := positiveOffset(!buf->array, pos);
+        let old: T := load(ptr);
+        -- Transform it.
+        let new: T := fn(old);
+        -- Store the new version.
+        store(ptr, new);
+        -- End.
+        return nil;
+    end;
+
     generic [T: Free, R: Region]
     function fill(buf: &![Buffer[T], R], element: T): Unit is
         for i from 0 to (!buf->size) - 1 do

--- a/standard/test/Buffer.aum
+++ b/standard/test/Buffer.aum
@@ -16,7 +16,8 @@ import Standard.Buffer (
     remove,
     removeFirst,
     removeLast,
-    reverse
+    reverse,
+    swapTransform
 );
 import Standard.Test.Unit (
     assertTrue,
@@ -34,6 +35,7 @@ module body Standard.Test.Buffer is
         storeTest();
         swapNthTest();
         swapIndexTest();
+        swapTransformTest();
         fillTest();
         insertFrontTest();
         insertBackTest();
@@ -100,6 +102,21 @@ module body Standard.Test.Buffer is
         swapIndex(&!b, 0, 1);
         assertTrue(nth(&b, 0) = 20, "[0] = 20");
         assertTrue(nth(&b, 1) = 10, "[1] = 10");
+        destroyFree(b);
+        assertSuccess("destroyFree complete");
+        return nil;
+    end;
+
+    function double(i: Int32): Int32 is
+        return 2 * i;
+    end;
+
+    function swapTransformTest(): Unit is
+        testHeading("swapTransform");
+        let b: Buffer[Int32] := initialize(1, 30);
+        assertLength(&b, 1);
+        swapTransform(&!b, 0, double);
+        assertTrue(nth(&b, 0) = 60, "[0] = 60");
         destroyFree(b);
         assertSuccess("destroyFree complete");
         return nil;

--- a/standard/test/Buffer.aum
+++ b/standard/test/Buffer.aum
@@ -17,7 +17,8 @@ import Standard.Buffer (
     removeFirst,
     removeLast,
     reverse,
-    swapTransform
+    swapTransform,
+    inPlaceMap
 );
 import Standard.Test.Unit (
     assertTrue,
@@ -43,6 +44,7 @@ module body Standard.Test.Buffer is
         removeLastTest();
         reverseEmptyTest();
         reverseNonEmptyTest();
+        inPlaceMapTest();
         return nil;
     end;
 
@@ -271,6 +273,29 @@ module body Standard.Test.Buffer is
         assertNth(&b, 1, 2);
         assertNth(&b, 2, 1);
         destroyFree(b);
+        return nil;
+    end;
+
+    function inPlaceMapTest(): Unit is
+        testHeading("inPlaceMap");
+        -- Create an array [1,2,3,4,5]
+        let b: Buffer[Int32] := allocateEmpty();
+        insertBack(&!b, 1);
+        insertBack(&!b, 2);
+        insertBack(&!b, 3);
+        insertBack(&!b, 4);
+        insertBack(&!b, 5);
+        -- Double each element in place.
+        inPlaceMap(&!b, double);
+        -- Assert contents.
+        assertTrue(nth(&b, 0) = 2,  "[0] = 2");
+        assertTrue(nth(&b, 1) = 4,  "[1] = 4");
+        assertTrue(nth(&b, 2) = 6,  "[2] = 6");
+        assertTrue(nth(&b, 3) = 8,  "[3] = 8");
+        assertTrue(nth(&b, 4) = 10, "[4] = 10");
+        -- End.
+        destroyFree(b);
+        assertSuccess("destroyFree complete");
         return nil;
     end;
 

--- a/standard/test/Buffer.aum
+++ b/standard/test/Buffer.aum
@@ -18,7 +18,8 @@ import Standard.Buffer (
     removeLast,
     reverse,
     swapTransform,
-    inPlaceMap
+    inPlaceMap,
+    map
 );
 import Standard.Test.Unit (
     assertTrue,
@@ -45,6 +46,7 @@ module body Standard.Test.Buffer is
         reverseEmptyTest();
         reverseNonEmptyTest();
         inPlaceMapTest();
+        mapTest();
         return nil;
     end;
 
@@ -295,6 +297,47 @@ module body Standard.Test.Buffer is
         assertTrue(nth(&b, 4) = 10, "[4] = 10");
         -- End.
         destroyFree(b);
+        assertSuccess("destroyFree complete");
+        return nil;
+    end;
+
+    union CardinalDirection: Free is
+        case North;
+        case South;
+        case East;
+        case West;
+    end;
+
+    function directionToChar(dir: CardinalDirection): Nat8 is
+        case dir of
+            when North do
+                return 'N';
+            when South do
+                return 'S';
+            when East do
+                return 'E';
+            when West do
+                return 'W';
+        end case;
+    end;
+
+    function mapTest(): Unit is
+        testHeading("map");
+        -- Create an array [North, South, East, West]
+        let b1: Buffer[CardinalDirection] := allocateEmpty();
+        insertBack(&!b1, North());
+        insertBack(&!b1, South());
+        insertBack(&!b1, East());
+        insertBack(&!b1, West());
+        -- Map each of the cardinal directions into a character.
+        let b2: Buffer[Nat8] := map(b1, directionToChar);
+        -- Assert the contents.
+        assertTrue(nth(&b2, 0) = 'N',  "[0] = N");
+        assertTrue(nth(&b2, 1) = 'S',  "[1] = S");
+        assertTrue(nth(&b2, 2) = 'E',  "[2] = E");
+        assertTrue(nth(&b2, 3) = 'W',  "[3] = W");
+        -- End.
+        destroyFree(b2);
         assertSuccess("destroyFree complete");
         return nil;
     end;


### PR DESCRIPTION
This PR implements the following functions for buffers:

- `swapTransform`: swap elements in place by transforming them through a function
- `inPlaceMap`: special case of map where the function is `T->T` so we can reuse storage.
- `map`: the generic `map` function, consumes the old buffer and returns a new one