### PR TITLE
Add BitwiseOperations typeclass to pervasives module

### DIFF
--- a/lib/BuiltIn.ml
+++ b/lib/BuiltIn.ml
@@ -51,6 +51,11 @@ let pervasive_imports =
         ConcreteImport (make_ident "modularSubtract", None);
         ConcreteImport (make_ident "modularMultiply", None);
         ConcreteImport (make_ident "modularDivide", None);
+        ConcreteImport (make_ident "BitwiseOperations", None);
+        ConcreteImport (make_ident "bitwiseAnd", None);
+        ConcreteImport (make_ident "bitwiseOr", None);
+        ConcreteImport (make_ident "bitwiseXor", None);
+        ConcreteImport (make_ident "bitwiseNot", None);
         ConcreteImport (make_ident "Printable", None);
         ConcreteImport (make_ident "print", None);
         ConcreteImport (make_ident "printLn", None);

--- a/lib/builtin/Pervasive.aui
+++ b/lib/builtin/Pervasive.aui
@@ -74,6 +74,13 @@ module Austral.Pervasive is
         method modularDivide(lhs: T, rhs: T): T;
     end;
 
+    typeclass BitwiseOperations(T: Type) is
+        method bitwiseAnd(lhs: T, rhs: T): T;
+        method bitwiseOr(lhs: T, rhs: T): T;
+        method bitwiseXor(lhs: T, rhs: T): T;
+        method bitwiseNot(value: T): T;
+    end;
+
     instance TrappingArithmetic(Nat8);
     instance TrappingArithmetic(Int8);
     instance TrappingArithmetic(Nat16);
@@ -96,6 +103,17 @@ module Austral.Pervasive is
     instance ModularArithmetic(Int64);
     instance ModularArithmetic(Index);
     instance ModularArithmetic(ByteSize);
+
+    instance BitwiseOperations(Nat8);
+    instance BitwiseOperations(Int8);
+    instance BitwiseOperations(Nat16);
+    instance BitwiseOperations(Int16);
+    instance BitwiseOperations(Nat32);
+    instance BitwiseOperations(Int32);
+    instance BitwiseOperations(Nat64);
+    instance BitwiseOperations(Int64);
+    instance BitwiseOperations(Index);
+    instance BitwiseOperations(ByteSize);
 
     typeclass Printable(A: Free) is
         method print(value: A): Unit;

--- a/lib/builtin/Pervasive.aum
+++ b/lib/builtin/Pervasive.aum
@@ -678,6 +678,191 @@ module body Austral.Pervasive is
     end;
 
     ---
+    --- Bitwise Operations
+    ---
+
+    instance BitwiseOperations(Nat8) is
+        method bitwiseAnd(lhs: Nat8, rhs: Nat8): Nat8 is
+            return @embed(Nat8, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Nat8, rhs: Nat8): Nat8 is
+            return @embed(Nat8, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Nat8, rhs: Nat8): Nat8 is
+            return @embed(Nat8, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Nat8): Nat8 is
+            return @embed(Nat8, "~ $1", value);
+        end;
+
+    end;
+
+    instance BitwiseOperations(Int8) is
+        method bitwiseAnd(lhs: Int8, rhs: Int8): Int8 is
+            return @embed(Int8, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Int8, rhs: Int8): Int8 is
+            return @embed(Int8, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Int8, rhs: Int8): Int8 is
+            return @embed(Int8, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Int8): Int8 is
+            return @embed(Int8, "~ $1", value);
+        end;
+    end;
+
+    instance BitwiseOperations(Nat16) is
+        method bitwiseAnd(lhs: Nat16, rhs: Nat16): Nat16 is
+            return @embed(Nat16, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Nat16, rhs: Nat16): Nat16 is
+            return @embed(Nat16, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Nat16, rhs: Nat16): Nat16 is
+            return @embed(Nat16, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Nat16): Nat16 is
+            return @embed(Nat16, "~ $1", value);
+        end;
+    end;
+
+    instance BitwiseOperations(Int16) is
+        method bitwiseAnd(lhs: Int16, rhs: Int16): Int16 is
+            return @embed(Int16, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Int16, rhs: Int16): Int16 is
+            return @embed(Int16, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Int16, rhs: Int16): Int16 is
+            return @embed(Int16, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Int16): Int16 is
+            return @embed(Int16, "~ $1", value);
+        end;
+    end;
+
+    instance BitwiseOperations(Nat32) is
+        method bitwiseAnd(lhs: Nat32, rhs: Nat32): Nat32 is
+            return @embed(Nat32, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Nat32, rhs: Nat32): Nat32 is
+            return @embed(Nat32, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Nat32, rhs: Nat32): Nat32 is
+            return @embed(Nat32, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Nat32): Nat32 is
+            return @embed(Nat32, "~ $1", value);
+        end;
+    end;
+
+    instance BitwiseOperations(Int32) is
+        method bitwiseAnd(lhs: Int32, rhs: Int32): Int32 is
+            return @embed(Int32, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Int32, rhs: Int32): Int32 is
+            return @embed(Int32, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Int32, rhs: Int32): Int32 is
+            return @embed(Int32, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Int32): Int32 is
+            return @embed(Int32, "~ $1", value);
+        end;
+    end;
+
+    instance BitwiseOperations(Nat64) is
+        method bitwiseAnd(lhs: Nat64, rhs: Nat64): Nat64 is
+            return @embed(Nat64, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Nat64, rhs: Nat64): Nat64 is
+            return @embed(Nat64, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Nat64, rhs: Nat64): Nat64 is
+            return @embed(Nat64, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Nat64): Nat64 is
+            return @embed(Nat64, "~ $1", value);
+        end;
+    end;
+
+    instance BitwiseOperations(Int64) is
+        method bitwiseAnd(lhs: Int64, rhs: Int64): Int64 is
+            return @embed(Int64, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Int64, rhs: Int64): Int64 is
+            return @embed(Int64, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Int64, rhs: Int64): Int64 is
+            return @embed(Int64, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Int64): Int64 is
+            return @embed(Int64, "~ $1", value);
+        end;
+    end;
+
+    instance BitwiseOperations(Index) is
+        method bitwiseAnd(lhs: Index, rhs: Index): Index is
+            return @embed(Index, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: Index, rhs: Index): Index is
+            return @embed(Index, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: Index, rhs: Index): Index is
+            return @embed(Index, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: Index): Index is
+            return @embed(Index, "~ $1", value);
+        end;
+    end;
+
+    instance BitwiseOperations(ByteSize) is
+        method bitwiseAnd(lhs: ByteSize, rhs: ByteSize): ByteSize is
+            return @embed(ByteSize, "$1 & $2", lhs, rhs);
+        end;
+
+        method bitwiseOr(lhs: ByteSize, rhs: ByteSize): ByteSize is
+            return @embed(ByteSize, "$1 | $2", lhs, rhs);
+        end;
+
+        method bitwiseXor(lhs: ByteSize, rhs: ByteSize): ByteSize is
+            return @embed(ByteSize, "$1 ^ $2", lhs, rhs);
+        end;
+
+        method bitwiseNot(value: ByteSize): ByteSize is
+            return @embed(ByteSize, "~ $1", value);
+        end;
+    end;
+
+    ---
     --- Printable
     ---
 

--- a/test-programs/suites/012-numbers/bitwise-operations/README.md
+++ b/test-programs/suites/012-numbers/bitwise-operations/README.md
@@ -1,0 +1,1 @@
+Test of BitwiseOperations typeclass.

--- a/test-programs/suites/012-numbers/bitwise-operations/Test.aum
+++ b/test-programs/suites/012-numbers/bitwise-operations/Test.aum
@@ -1,0 +1,38 @@
+module body Test is
+
+    generic[T: Free(BitwiseOperations, Printable)]
+    function assertEqual(expected: T, actual: T, description: FixedArray[Nat8]): Unit is
+        if expected /= actual then
+            printLn(description);
+            print("EXPCTED "); print(expected); print(" ACTUAL "); printLn(actual);
+        end if;
+        return nil;
+    end;
+
+    generic[T: Free(BitwiseOperations)]
+    function test(placeholder: T): Unit is
+        let a: T := 3; -- bits 0011
+        let b: T := 5; -- bits 0101
+        assertEqual(1, bitwiseAnd(a, b), "FAILED bitwiseAnd");
+        assertEqual(7, bitwiseOr(a, b), "FAILED bitwiseOr");
+        assertEqual(6, bitwiseXor(a, b), "FAILED bitwiseXor");
+        assertEqual(12, bitwiseAnd(15, bitwiseNot(a)), "FAILED bitwiseNot");
+        return nil;
+    end;
+
+    function main(): ExitCode is
+        printLn("Start");
+        test(0 : Nat8);
+        test(0 : Int8);
+        test(0 : Nat16);
+        test(0 : Int16);
+        test(0 : Nat32);
+        test(0 : Int32);
+        test(0 : Nat64);
+        test(0 : Int64);
+        test(0 : Index);
+        test(0 : ByteSize);
+        printLn("End");
+        return ExitSuccess();
+    end;
+end module body.

--- a/test-programs/suites/012-numbers/bitwise-operations/program-stdout.txt
+++ b/test-programs/suites/012-numbers/bitwise-operations/program-stdout.txt
@@ -1,0 +1,2 @@
+Start
+End


### PR DESCRIPTION
This is an attempt to add BitwiseOperations typeclass and implementation to the pervasives module.  I did not add shift left and shift right as these can be achieved by multiplying or dividing by powers of 2.