### PR TITLE
Remove unused deref and derefWrite functions from Austral.Pervasive

### DIFF
--- a/lib/BuiltIn.ml
+++ b/lib/BuiltIn.ml
@@ -16,8 +16,6 @@ let pervasive_imports =
         ConcreteImport (make_ident "Either", None);
         ConcreteImport (make_ident "Left", None);
         ConcreteImport (make_ident "Right", None);
-        ConcreteImport (make_ident "deref", None);
-        ConcreteImport (make_ident "derefWrite", None);
         ConcreteImport (make_ident "fixedArraySize", None);
         ConcreteImport (make_ident "abort", None);
         ConcreteImport (make_ident "RootCapability", None);

--- a/lib/builtin/Pervasive.aui
+++ b/lib/builtin/Pervasive.aui
@@ -12,12 +12,6 @@ module Austral.Pervasive is
             right: R;
     end;
 
-    generic [T: Free, R: Region]
-    function deref(ref: &[T, R]): T;
-
-    generic [T: Free, R: Region]
-    function derefWrite(ref: &![T, R]): T;
-
     generic [T: Type]
     function fixedArraySize(arr: FixedArray[T]): Index;
 

--- a/lib/builtin/Pervasive.aum
+++ b/lib/builtin/Pervasive.aum
@@ -1,14 +1,4 @@
 module body Austral.Pervasive is
-    generic [T: Free, R: Region]
-    function deref(ref: &[T, R]): T is
-        return @embed(T, "*$1", ref);
-    end;
-
-    generic [T: Free, R: Region]
-    function derefWrite(ref: &![T, R]): T is
-        return @embed(T, "*$1", ref);
-    end;
-
     generic [T: Type]
     function fixedArraySize(arr: FixedArray[T]): Index is
         return @embed(Index, "$1.size", arr);


### PR DESCRIPTION
These are obsolete.