### PR TITLE
Make dereferencing an atomic expression

### DIFF
--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -389,6 +389,7 @@ atomic_expression:
   | SIZEOF LPAREN typespec RPAREN { CSizeOf (from_loc $loc, $3) }
   | BORROW_READ identifier { CBorrowExpr (from_loc $loc, ReadBorrow, $2) }
   | BORROW_WRITE identifier { CBorrowExpr (from_loc $loc, WriteBorrow, $2) }
+  | DEREF atomic_expression { CDeref (from_loc $loc, $2) }
   ;
 
 int_constant:
@@ -449,7 +450,6 @@ compound_expression:
   | atomic_expression AND atomic_expression { CConjunction (from_loc $loc, $1, $3) }
   | atomic_expression OR atomic_expression { CDisjunction (from_loc $loc, $1, $3) }
   | NOT atomic_expression { CNegation (from_loc $loc, $2) }
-  | DEREF atomic_expression { CDeref (from_loc $loc, $2) }
   | arith_expr { $1 }
   | IF expression THEN expression ELSE expression { CIfExpression (from_loc $loc, $2, $4, $6) }
   | atomic_expression COLON typespec { CTypecast (from_loc $loc, $1, $3) }

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -48,11 +48,11 @@ module body Standard.Buffer is
     function invariants(buf: &[Buffer[T], R]): Unit is
         -- Size is always strictly less than the capacity. When resizing, if
         -- the size matches the capacity, we bump up.
-        if (!buf->size) >= (!buf->capacity) then
+        if !buf->size >= !buf->capacity then
             abort("Buffer size >= capacity");
         end if;
         -- Capacity is always non-zero.
-        if (!buf->capacity) = 0 then
+        if !buf->capacity = 0 then
             abort("Buffer capacity = 0");
         end if;
         return nil;
@@ -168,7 +168,7 @@ module body Standard.Buffer is
 
     generic [T: Free, R: Region]
     function nth(buf: &[Buffer[T], R], pos: Index): T is
-        if pos >= (!buf->size) then
+        if pos >= !buf->size then
             abort("nth: index out of range");
         end if;
         let ptr: Pointer[T] := positiveOffset(!buf->array, pos);
@@ -182,7 +182,7 @@ module body Standard.Buffer is
 
     generic [T: Free, R: Region]
     function storeNth(buf: &![Buffer[T], R], pos: Index, element: T): Unit is
-        if pos >= (!buf->size) then
+        if pos >= !buf->size then
             abort("storeNth: index out of range");
         end if;
         let ptr: Pointer[T] := positiveOffset(!buf->array, pos);
@@ -194,7 +194,7 @@ module body Standard.Buffer is
 
     generic [T: Type, R: Region]
     function swapNth(buf: &![Buffer[T], R], pos: Index, element: T): T is
-        if pos >= (!buf->size) then
+        if pos >= !buf->size then
             abort("swapNth: index out of range");
         end if;
         let ptr: Pointer[T] := positiveOffset(!buf->array, pos);
@@ -206,10 +206,10 @@ module body Standard.Buffer is
 
     generic [T: Type, R: Region]
     function swapIndex(buf: &![Buffer[T], R], a: Index, b: Index): Unit is
-        if a >= (!buf->size) then
+        if a >= !buf->size then
             abort("swapIndex: first index out of range");
         end if;
-        if b >= (!buf->size) then
+        if b >= !buf->size then
             abort("swapIndex: second index out of range");
         end if;
         -- Load a and b.
@@ -227,7 +227,7 @@ module body Standard.Buffer is
 
     generic [T: Type, R: Region]
     function swapTransform(buf: &![Buffer[T], R], pos: Index, fn: Fn[T, T]): Unit is
-        if pos >= (!buf->size) then
+        if pos >= !buf->size then
             abort("swapTransform: index out of range");
         end if;
         -- Load the element at `pos`.
@@ -243,7 +243,7 @@ module body Standard.Buffer is
 
     generic [T: Free, R: Region]
     function fill(buf: &![Buffer[T], R], element: T): Unit is
-        for i from 0 to (!buf->size) - 1 do
+        for i from 0 to !buf->size - 1 do
             storeNth(buf, i, element);
         end for;
         -- invariants(buf : &[Buffer[T], R]);
@@ -261,7 +261,7 @@ module body Standard.Buffer is
     """
     generic [T: Type, R: Region]
     function bump(buf: &![Buffer[T], R]): Unit is
-        let new_capacity: Index := (!buf->capacity) * 2;
+        let new_capacity: Index := !buf->capacity * 2;
         let new_addr: Address[T] := resizeArray(!buf->array, new_capacity);
         case nullCheck(new_addr) of
             when Some(value as new_array: Pointer[T]) do
@@ -282,28 +282,28 @@ module body Standard.Buffer is
     generic [T: Type, R: Region]
     function insert(buf: &![Buffer[T], R], pos: Index, element: T): Unit is
         -- Check `pos` is in bounds.
-        if pos > (!buf->size) then
+        if pos > !buf->size then
             abort("insert: index out of range");
         end if;
         -- If insertion would increase make `size` match `capacity`, resize
         -- the array.
-        if ((!buf->size) + 1) = (!buf->capacity) then
+        if (!buf->size + 1) = !buf->capacity then
             bump(buf);
         end if;
         -- If the array is non-empty, we have to move everything to the right of
         -- the position one step to the right.
-        if (!buf->size) > 0 then
+        if !buf->size > 0 then
            shiftRight(
                ptr => !buf->array,
                chunk_start => pos,
-               chunk_length => (!buf->size) - pos,
+               chunk_length => !buf->size - pos,
                count => 1
            );
         end if;
         -- Insert.
         let index_ptr: Pointer[T] := positiveOffset(!buf->array, pos);
         store(index_ptr, element);
-        buf->size := (!buf->size) + 1;
+        buf->size := !buf->size + 1;
         -- invariants(buf : &[Buffer[T], R]);
         return nil;
     end;
@@ -325,25 +325,25 @@ module body Standard.Buffer is
     generic [T: Type, R: Region]
     function remove(buf: &![Buffer[T], R], pos: Index): T is
         -- Check array is non-empty.
-        if (!buf->size) = 0 then
+        if !buf->size = 0 then
             abort("remove: array is empty");
         end if;
         -- Check position is in bounds.
-        if pos >= (!buf->size) then
+        if pos >= !buf->size then
             abort("insert: index out of range");
         end if;
         let ptr: Pointer[T] := positiveOffset(!buf->array, pos);
         let elem: T := load(ptr);
         -- Move all elements right form `pos` one step to the left, unless this is the last index of the array.
-        if pos < ((!buf->size) - 1) then
+        if pos < (!buf->size - 1) then
             shiftLeft(
                 ptr => !buf->array,
                 chunk_start => pos + 1,
-                chunk_length => ((!buf->size) - 1) - pos,
+                chunk_length => (!buf->size - 1) - pos,
                 count => 1
             );
         end if;
-        buf->size := (!buf->size) - 1;
+        buf->size := !buf->size - 1;
         -- invariants(buf : &[Buffer[T], R]);
         return elem;
     end;
@@ -355,7 +355,7 @@ module body Standard.Buffer is
 
     generic [T: Type, R: Region]
     function removeLast(buf: &![Buffer[T], R]): T is
-        return remove(buf, (!buf->size) - 1);
+        return remove(buf, !buf->size - 1);
     end;
 
     ---
@@ -364,9 +364,9 @@ module body Standard.Buffer is
 
     generic [T: Type, R: Region]
     function reverse(buf: &![Buffer[T], R]): Unit is
-        if (!buf->size) > 0 then
-            for i from 0 to (!buf->size) / 2 do
-                let j: Index := ((!buf->size) - i) - 1;
+        if !buf->size > 0 then
+            for i from 0 to !buf->size / 2 do
+                let j: Index := (!buf->size - i) - 1;
                 swapIndex(buf, i, j);
             end for;
         end if;
@@ -380,7 +380,7 @@ module body Standard.Buffer is
 
     generic [T: Type, R: Region]
     function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit is
-        for i from 0 to (!buf->size) - 1 do
+        for i from 0 to !buf->size - 1 do
             swapTransform(buf, i, fn);
         end for;
         return nil;


### PR DESCRIPTION
Saves parentheses.

Fixes #389.