### PR TITLE
Fix code generation of named structs that depend on each other

### DIFF
--- a/test-programs/suites/001-trivial/014-named-records/README.md
+++ b/test-programs/suites/001-trivial/014-named-records/README.md
@@ -1,0 +1,1 @@
+Test of that records referencing each other can compile

--- a/test-programs/suites/001-trivial/014-named-records/Test.aum
+++ b/test-programs/suites/001-trivial/014-named-records/Test.aum
@@ -1,0 +1,21 @@
+module body Test is
+
+    record PollMap: Linear is
+        b: B;
+    end;
+
+    record C[X: Type]: Type is
+       x : X;
+    end;
+
+    record B: Linear is
+        xs: C[Nat32];
+    end;
+    
+    function main(): ExitCode is
+        printLn("Start");
+        -- if it compiles, then this test is a success
+        printLn("End");
+        return ExitSuccess();
+    end;
+end module body.

--- a/test-programs/suites/001-trivial/014-named-records/program-stdout.txt
+++ b/test-programs/suites/001-trivial/014-named-records/program-stdout.txt
@@ -1,0 +1,2 @@
+Start
+End


### PR DESCRIPTION
The earlier fix for this problem did not work in all cases. Specifically, named structs in the same module that depend on each other could still be generated in the wrong order. The C compiler would complain that the struct embedded in a struct definition was not fully defined.

I have very limited OCaml skills, having briefly used the language for a few months in 2002, and my attempt at a fix is messy and gross. I'm 100% certain there are better ways to put it together and have thought of a few. However, this messy fix is working for me and has unblocked my work on implementing a hashtable in Austral.

I'm sharing it here in case you can look at it and quickly see the easy and smart way of implementing it :-)

The point of the change is that we calculate a score for each named struct which is its "depth", that is 1 more than the max of the "depth" of its field types. When sorting named structs against each other, using this depth ensures that structs are always emitted after the struct definitions they depend on.