### PR TITLE
Lex line comments with no trailing newline.

### DIFF
--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -34,7 +34,7 @@ let exponent = 'e' | 'E'
 let sign = '+' | '-'
 let period = '.'
 
-let comment = "--" [^ '\r' '\n']* (newline)
+let comment = "--" [^ '\r' '\n']* newline?
 
 (* Token regexes *)
 

--- a/test-programs/suites/011-bugs/github-422/README.md
+++ b/test-programs/suites/011-bugs/github-422/README.md
@@ -1,0 +1,1 @@
+Regression test for [GitHub issue #422](https://github.com/austral/austral/issues/422).

--- a/test-programs/suites/011-bugs/github-422/Test.aum
+++ b/test-programs/suites/011-bugs/github-422/Test.aum
@@ -1,0 +1,6 @@
+module body Test is
+  function main(): ExitCode is
+    return ExitSuccess();
+  end;
+end module body.
+-- test


### PR DESCRIPTION
Fixes #422. The spec does require line comments to end with a newline character, but I think that's an unnecessary restriction, so I'm happy to update it too if this is okay.