### PR TITLE
Replace many uses of `err` with `austral_raise`

### DIFF
--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -61,6 +61,13 @@ open Error
 
 *)
 
+module Errors = struct
+  let foreign_returns_array () =
+    austral_raise DeclarationError [
+      Text "Foreign functions cannot return arrays."
+    ]
+end
+
 (* Name generation *)
 
 let counter = ref 0
@@ -523,7 +530,7 @@ let gen_decl (env: env) (mn: module_name) (decl: mdecl): c_decl list =
      let return_type_to_c_type t =
        match t with
        | MonoStaticArray _ ->
-          err "Foreign functions cannot return arrays."
+          Errors.foreign_returns_array ()
        | _ ->
           param_type_to_c_type t
      in

--- a/lib/CombiningPass.ml
+++ b/lib/CombiningPass.ml
@@ -12,6 +12,75 @@ open ImportResolution
 open Reporter
 open Error
 
+module Errors = struct
+  let declaration_kind_mismatch ~name ~expected =
+    austral_raise DeclarationError [
+      Text "The interface requires ";
+      Code (ident_string name);
+      Text " to be a ";
+      Text expected
+    ]
+
+  let function_mismatch ~name ~typarams ~params ~rt =
+    let message = match typarams, params, rt with
+    | true, false, false -> "have different type parameters."
+    | false, true, false -> "have different parameters."
+    | false, false, true -> "have different return types"
+    | _ -> "are different."
+    in
+    austral_raise DeclarationError [
+      Text "The interface declaration for ";
+      Code (ident_string name);
+      Text " and its implementation ";
+      Text message
+    ]
+
+  let missing_body_definition ~name ~declaration =
+    match declaration with
+    | Some declaration -> 
+       austral_raise DeclarationError [
+         Text "The ";
+         Text declaration;
+         Text " ";
+         Code (ident_string name);
+         Text " has no corresponding body implementation."
+       ]
+    | None -> 
+       austral_raise DeclarationError [
+         Code (ident_string name);
+         Text " has no corresponding body implementation."
+       ]
+
+  let module_name_mismatch ~interface ~body =
+    austral_raise DeclarationError [
+      Text "Module interface and body have different names: ";
+      Code (mod_name_string interface);
+      Text " and ";
+      Code (mod_name_string body)
+    ]
+
+  let multiarg_typeclass name =
+    austral_raise DeclarationError [
+      Text "The typeclass ";
+      Code (ident_string name);
+      Text " has multiple parameters, which is unsupported."
+    ]
+
+  let type_mismatch name =
+    austral_raise DeclarationError [
+      Text "The interface declaration for ";
+      Code (ident_string name);
+      Text " and its implementation have different types."
+    ]
+
+  let universe_mismatch name =
+    austral_raise DeclarationError [
+      Text "The interface declaration for ";
+      Code (ident_string name);
+      Text " and its implementation have different universes."
+    ]
+end
+
 let parse_slots (imports: import_map) (slots: concrete_slot list): qslot list =
   List.map
     (fun (ConcreteSlot (n, t)) -> QualifiedSlot (n, qualify_typespec imports t))
@@ -68,9 +137,9 @@ let match_decls (module_name: module_name) (ii: import_map) (bi: import_map) (de
          if (name = name') && (ty = ty') then
            CConstant (VisPublic, name, qualify_typespec ii ty, abs_expr bi value, docstring)
          else
-           err "Mismatch"
+           Errors.type_mismatch name
       | _ ->
-         err "Not a constant")
+         Errors.declaration_kind_mismatch ~name ~expected:"constant")
   | ConcreteOpaqueTypeDecl (name, typarams, universe, docstring) ->
      (match def with
       | ConcreteRecordDef (ConcreteRecord (name', typarams', universe', slots, _)) ->
@@ -83,7 +152,10 @@ let match_decls (module_name: module_name) (ii: import_map) (bi: import_map) (de
                     parse_slots bi slots,
                     docstring)
          else
-           err "Mismatch"
+           if universe != universe' then
+             Errors.universe_mismatch name
+           else
+             Errors.type_mismatch name
       | ConcreteUnionDef (ConcreteUnion (name', typarams', universe', cases, _)) ->
          if (name = name') && (typarams = typarams') && (universe = universe') then
            let qname = make_qname name' in
@@ -94,9 +166,12 @@ let match_decls (module_name: module_name) (ii: import_map) (bi: import_map) (de
                    parse_cases bi cases,
                    docstring)
          else
-           err "Mismatch"
+           if universe <> universe' then
+             Errors.universe_mismatch name
+           else
+             Errors.type_mismatch name
       | _ ->
-         err "Not a type")
+         Errors.declaration_kind_mismatch ~name ~expected:"type")
   | ConcreteFunctionDecl (name, typarams, params, rt, docstring) ->
      (match def with
       | ConcreteFunctionDef (name', typarams', params', rt', body, _, pragmas) ->
@@ -111,9 +186,13 @@ let match_decls (module_name: module_name) (ii: import_map) (bi: import_map) (de
                       docstring,
                       pragmas)
          else
-           err "Function declaration does not match definition"
+           Errors.function_mismatch
+             ~name
+             ~typarams:(typarams = typarams')
+             ~params:(params = params')
+             ~rt:(rt = rt')
       | _ ->
-         err "Not a function")
+         Errors.declaration_kind_mismatch ~name ~expected:"function")
   | ConcreteInstanceDecl (name, typarams, argument, docstring) ->
      (match def with
       | ConcreteInstanceDef (ConcreteInstance (name', typarams', argument', methods, _)) ->
@@ -131,9 +210,9 @@ let match_decls (module_name: module_name) (ii: import_map) (bi: import_map) (de
                       parse_method_defs module_name bi methods,
                       docstring)
          else
-           err "Mismatch"
+           Errors.type_mismatch name
       | _ ->
-         err "Not an instance")
+         Errors.declaration_kind_mismatch ~name ~expected:"instance")
   | _ ->
      err "Invalid decl in this context"
 
@@ -182,7 +261,7 @@ let private_def module_name im def =
                   | [tp] ->
                      tp
                   | _ ->
-                     err "typeclass has more than one parameter"),
+                     Errors.multiarg_typeclass name),
                  parse_method_decls module_name im methods,
                  docstring)
   | ConcreteInstanceDef (ConcreteInstance (name, typarams, argument, methods, docstring)) ->
@@ -206,10 +285,7 @@ let rec combine (env: env) (cmi: concrete_module_interface) (cmb: concrete_modul
       in
       ps ("Module name", (mod_name_string mn));
       if mn <> mn' then
-        err ("Interface and body have mismatching names: "
-             ^ (mod_name_string mn)
-             ^ " and "
-             ^ (mod_name_string mn'))
+        Errors.module_name_mismatch ~interface:mn ~body:mn'
       else
         let im = resolve mn kind env interface_imports
         and bm = resolve mn kind env body_imports
@@ -259,7 +335,7 @@ and parse_decl (module_name: module_name) (im: import_map) (bm: import_map) (cmb
                   | [tp] ->
                      tp
                   | _ ->
-                     err "typeclass has more than one parameter"),
+                     Errors.multiarg_typeclass name),
                      parse_method_decls module_name im methods,
                      docstring)
       | _ ->
@@ -268,7 +344,7 @@ and parse_decl (module_name: module_name) (im: import_map) (bm: import_map) (cmb
           | (Some def) ->
              match_decls module_name im bm decl def
           | None ->
-             err "Interface declaration has no corresponding body declaration"))
+             Errors.missing_body_definition ~name ~declaration:None))
   | None ->
      (match decl with
       | ConcreteInstanceDecl (name, typarams, argument, _) ->
@@ -277,7 +353,7 @@ and parse_decl (module_name: module_name) (im: import_map) (bm: import_map) (cmb
           | (Some def) ->
              match_decls module_name im bm decl (ConcreteInstanceDef def)
           | None ->
-             err "Interface declaration has no corresponding body declaration")
+             Errors.missing_body_definition ~name ~declaration:(Some "instance"))
       | _ ->
          internal_err "Couldn't parse declaration declaration")
 

--- a/lib/Entrypoint.ml
+++ b/lib/Entrypoint.ml
@@ -10,8 +10,55 @@ open Names
 open CodeGen
 open MonoTypeBindings
 
-let entrypoint_err (text: err_text): 'a =
-  austral_raise EntrypointError text
+module Errors = struct
+  let multiple_parameters () =
+    austral_raise EntrypointError [
+      Text "The entrypoint function should take a single parameter with type ";
+      Code "RootCapability";
+      Text ", or none at all, but it has several."
+    ]
+
+  let no_such_function ~name ~module_name =
+    austral_raise EntrypointError [
+      Text "No function named ";
+      Code (ident_string name);
+      Text " in module ";
+      Code (mod_name_string module_name)
+    ]
+
+  let not_function () =
+    austral_raise EntrypointError [
+      Text "The entrypoint must be a function."
+    ]
+
+  let not_monomorphic () =
+    austral_raise EntrypointError [
+      Text "The entrypoint function cannot be generic."
+    ]
+
+  let not_public () =
+    austral_raise EntrypointError [
+      Text "The entrypoint function is not public.";
+      Break;
+      Text "Consider declaring it in the module interface."
+    ]
+
+  let wrong_parameter_type ty =
+    austral_raise EntrypointError [
+      Text "The type of the entrypoint argument must be ";
+      Code "RootCapability";
+      Text " but it is ";
+      Code (type_string ty)
+    ]
+
+  let wrong_return_type ty =
+    austral_raise EntrypointError [
+      Text "The type of the entrypoint function must be ";
+      Code "ExitCode";
+      Text " but it is ";
+      Code (type_string ty)
+    ]
+end
 
 (** The kind of entrypoint function we have. *)
 type entrypoint_kind =
@@ -35,43 +82,28 @@ let rec check_entrypoint_validity (env: env) (name: qident): decl_id * entrypoin
                 if is_exit_code_type rt then
                   (id, EmptyEntrypoint)
                 else
-                  entrypoint_err [
-                      Text "The return type of the entrypoint function must be `ExitCode`, but I got ";
-                      Code (type_string rt);
-                      Text "."
-                    ]
+                  Errors.wrong_return_type rt
              | [ValueParameter (_, pt)] ->
                 (* Single parameter case: the `root` parameter. *)
                 if is_root_cap_type pt then
                   if is_exit_code_type rt then
                     (id, RootCapEntrypoint)
                   else
-                    entrypoint_err [
-                        Text "The return type of the entrypoint function must be `ExitCode`, but I got ";
-                        Code (type_string rt);
-                        Text "."
-                      ]
+                    Errors.wrong_return_type rt
                 else
-                  entrypoint_err [
-                      Text "The parameter to the entrypoint function must be of type RootCapability, but I got ";
-                      Code (type_string pt);
-                      Text "."
-                    ]
+                  Errors.wrong_parameter_type pt
              | _ ->
-                entrypoint_err [Text "Entrypoint function must take a single parameter of type RootCapability, or zero parameters, but I got a different parameter list."]
+                Errors.multiple_parameters ()
            else
-             entrypoint_err [Text "Entrypoint function cannot have type parameters generic."]
+             Errors.not_monomorphic ()
          else
-           entrypoint_err [Text "Entrypoint function is not public."]
+           Errors.not_public ()
       | _ ->
-         entrypoint_err [Text "Entrypoint is not a function."])
+         Errors.not_function ())
   | None ->
-     entrypoint_err [
-         Text "Entrypoint function ";
-         Code (ident_string (original_name name));
-         Text " does not exist in the module name ";
-         Code (mod_name_string (source_module_name name));
-       ]
+      Errors.no_such_function
+        ~name:(original_name name)
+        ~module_name:(source_module_name name)
 
 and is_root_cap_type = function
   | NamedType (name, [], LinearUniverse) ->

--- a/lib/Env.ml
+++ b/lib/Env.ml
@@ -21,6 +21,13 @@ module Errors = struct
       Text "."
     ]
 
+  let module_exists name =
+    austral_raise DeclarationError [
+      Text "A module with the name ";
+      Code (mod_name_string name);
+      Text " already exists."
+    ]
+
   let unknown_module name =
     austral_raise DeclarationError [
       Text "Unknown module ";
@@ -68,11 +75,7 @@ let get_module_by_name (env: env) (mod_name: module_name): mod_rec option =
 let ensure_no_mod_with_name (env: env) (name: module_name): unit =
   match get_module_by_name env name with
   | Some _ ->
-     austral_raise DeclarationError [
-         Text "A module with the name ";
-         Code (mod_name_string name);
-         Text " already exists.";
-       ]
+      Errors.module_exists name
   | None ->
      ()
 

--- a/lib/ExportInstantiation.ml
+++ b/lib/ExportInstantiation.ml
@@ -11,7 +11,7 @@ module Errors = struct
   let disallowed_type ty =
     austral_raise TypeError [
       Text "The type ";
-      Code ty;
+      Code (type_string ty);
       Text " is not allowed in the signature of an exported function."
     ]
 end
@@ -38,7 +38,7 @@ let get_export_data (env: env) (id: decl_id): (value_parameter list * ty) =
 let rec transform_ty (ty: ty): c_ty =
   match ty with
   | Unit ->
-     Errors.disallowed_type "Unit"
+     Errors.disallowed_type ty
   | Boolean ->
      CNamedType "au_bool_t"
   | Integer (s, w) ->
@@ -61,28 +61,28 @@ let rec transform_ty (ty: ty): c_ty =
      CNamedType "float"
   | DoubleFloat ->
      CNamedType "double"
-  | NamedType (name, _, _) ->
-     Errors.disallowed_type (qident_to_sident name |> sident_name |> ident_string)
+  | NamedType _ ->
+     Errors.disallowed_type ty
   | StaticArray (Integer (Unsigned, Width8)) ->
      c_string_type
   | StaticArray _ ->
-     Errors.disallowed_type "FixedArray"
+     Errors.disallowed_type ty
   | RegionTy _ ->
-     err "Not allowed"
+     Errors.disallowed_type ty
   | ReadRef _ ->
-     Errors.disallowed_type "Reference"
+     Errors.disallowed_type ty
   | WriteRef _ ->
-     Errors.disallowed_type "WriteReference"
+     Errors.disallowed_type ty
   | TyVar _ ->
-     err "Not allowed"
+     Errors.disallowed_type ty
   | Address t ->
      CPointer (transform_ty t)
   | Pointer _ ->
-     err "Not allowed"
+     Errors.disallowed_type ty
   | FnPtr _ ->
      fn_type
   | MonoTy _ ->
-     err "Not allowed"
+     Errors.disallowed_type ty
 
 let transform_param (ValueParameter (name, ty)): c_param =
   CValueParam (gen_ident name, transform_ty ty)

--- a/lib/ExtractionPass.ml
+++ b/lib/ExtractionPass.ml
@@ -42,12 +42,12 @@ module Errors = struct
     ]
 
   let free_contains_linear ~name ~universe ~parameter =
-    austral_raise DeclarationError [
+    austral_raise LinearityError [
       Code (ident_string name);
       Text " was declared to belong to the ";
       Code "Free";
-      Text " universe, but ";
-      Text (if parameter then "has a type parameter" else "contains a field");
+      Text " universe, but it ";
+      Text (if parameter then "has a type parameter" else "contains a type");
       Text " that belongs to the ";
       Code universe;
       Text " universe."

--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -3,6 +3,42 @@ open Lexing
 open Error
 open Parser
 
+module Errors = struct
+  let raise_err lexbuf kind text : 'a =
+    let error =
+      AustralError {
+        module_name = None;
+        kind = kind;
+        text = text;
+        span = Some (Span.from_lexbuf lexbuf);
+        source_ctx = None
+      }
+    in
+    raise (Austral_error error)
+
+  let invalid_character lexbuf =
+    raise_err lexbuf ParseError [
+      Text "Character not allowed in source text: ";
+      Code (Lexing.lexeme lexbuf)
+    ]
+
+  let single_string_invalid_character lexbuf =
+    raise_err lexbuf ParseError [
+      Text "Character not allowed in string literal: ";
+      Code (Lexing.lexeme lexbuf)
+    ]
+
+  let single_string_eof lexbuf =
+    raise_err lexbuf ParseError [
+      Text "End of file in string literal."
+    ]
+
+  let triple_string_eof lexbuf =
+    raise_err lexbuf ParseError [
+      Text "End of file in triple string literal."
+    ]
+end
+
 let advance_line lexbuf =
   let pos = lexbuf.lex_curr_p in
   let pos' = { pos with
@@ -10,7 +46,7 @@ let advance_line lexbuf =
     pos_lnum = pos.pos_lnum + 1
   } in
   lexbuf.lex_curr_p <- pos'
-
+  
 let string_acc: Buffer.t = Buffer.create 64
 
 let triple_string_acc: Buffer.t = Buffer.create 64
@@ -146,18 +182,20 @@ rule token = parse
   | whitespace { token lexbuf }
   | newline { advance_line lexbuf; token lexbuf }
   | eof { EOF }
-  | _ {err ("Character not allowed in source text: '" ^ Lexing.lexeme lexbuf ^ "'") }
+  | _ {
+    Errors.invalid_character lexbuf
+  }
 
 and read_string = parse
   | '"' { let c = Buffer.contents string_acc in Buffer.clear string_acc; STRING_CONSTANT c }
   | '\\' '"' { Buffer.add_char string_acc '"'; read_string lexbuf }
   | [^ '"'] { Buffer.add_string string_acc (Lexing.lexeme lexbuf); read_string lexbuf }
-  | eof { err "End of file in string literal" }
-  | _ {err ("Character not allowed in string literal: '" ^ Lexing.lexeme lexbuf ^ "'") }
+  | eof { Errors.single_string_eof lexbuf }
+  | _ { Errors.single_string_invalid_character lexbuf }
 
 and read_triple_string = parse
   | "\"\"\"" { let c = Buffer.contents triple_string_acc in Buffer.clear triple_string_acc; TRIPLE_STRING_CONSTANT c }
   | '\n' { advance_line lexbuf; Buffer.add_string triple_string_acc "\n"; read_triple_string lexbuf }
   | '\\' "\"\"\"" { Buffer.add_string triple_string_acc "\"\"\""; read_triple_string lexbuf }
-  | eof { err "End of file in triple-quoted string." }
+  | eof { Errors.triple_string_eof lexbuf }
   | _ { Buffer.add_string triple_string_acc (Lexing.lexeme lexbuf); read_triple_string lexbuf }

--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -34,7 +34,7 @@ let exponent = 'e' | 'E'
 let sign = '+' | '-'
 let period = '.'
 
-let comment = "--" [^ '\r' '\n']* (newline)
+let comment = "--" [^ '\r' '\n']* newline?
 
 (* Token regexes *)
 

--- a/lib/ReturnCheck.ml
+++ b/lib/ReturnCheck.ml
@@ -4,6 +4,17 @@ open Combined
 open Reporter
 open Error
 
+module Errors = struct
+  let missing_return ~name ~declaration =
+    austral_raise DeclarationError [
+      Text "The ";
+      Text declaration;
+      Text " ";
+      Code (ident_string name);
+      Text " does not end in a return statement."
+    ]
+end
+
 let is_abort (name: qident): bool =
   let mn: module_name = source_module_name name
   and orig: identifier = original_name name
@@ -45,18 +56,16 @@ let rec ends_in_return (stmt: astmt): bool =
   | AReturn _ ->
      true
 
-let check_ends_in_return (CombinedModule { name=mn; decls; _ }): unit =
+let check_ends_in_return (CombinedModule { decls; _ }): unit =
   with_frame "Return check"
     (fun _ ->
       let check_method_ends_in_return (CMethodDef (name, _, _, _, _, body)): unit =
         if ends_in_return body then
           ()
         else
-          err ("Method "
-               ^ (ident_string name)
-               ^ " in module "
-               ^ (mod_name_string mn)
-               ^ " doesn't end in a return statement.")
+          Errors.missing_return
+            ~name:name
+            ~declaration:"method"
       in
       let check_decl_ends_in_return (decl: combined_definition): unit =
         match decl with
@@ -73,11 +82,9 @@ let check_ends_in_return (CombinedModule { name=mn; decls; _ }): unit =
                if ends_in_return body then
                  ()
                else
-                 err ("Function "
-                      ^ (ident_string name)
-                      ^ " in module "
-                      ^ (mod_name_string mn)
-                      ^ " doesn't end in a return statement.")
+                 Errors.missing_return
+                   ~name
+                   ~declaration:"function"
             | _ ->
                (* Yes pragmas: foreign function, ignore the body. *)
                ())

--- a/lib/TastUtil.ml
+++ b/lib/TastUtil.ml
@@ -4,6 +4,16 @@ open Identifier
 open StringSet
 open Error
 
+module Errors = struct
+  let arity_error ~expected ~actual =
+    austral_raise TypeError [
+      Text "Wrong number of arguments. Expected ";
+      Text (string_of_int expected);
+      Text " but got ";
+      Text (string_of_int actual)
+    ]
+end
+
 let arglist_size = function
   | (TPositionalArglist l) -> List.length l
   | (TNamedArglist l) -> List.length l
@@ -18,14 +28,7 @@ let rec arglist_to_positional (args, names): texpr list =
     | (TPositionalArglist l) -> l
     | (TNamedArglist l) -> reorder_arglist l names
   else
-    austral_raise GenericError
-      [
-        Text "Wrong number of arguments. Expected ";
-        Code (string_of_int expected);
-        Text " and got ";
-        Code (string_of_int actual);
-        Text "."
-      ]
+    Errors.arity_error ~expected ~actual
 
 and names_match arglist names =
   match arglist with

--- a/lib/TastUtil.ml
+++ b/lib/TastUtil.ml
@@ -6,11 +6,12 @@ open Error
 
 module Errors = struct
   let arity_error ~expected ~actual =
-    austral_raise TypeError [
+    austral_raise GenericError [
       Text "Wrong number of arguments. Expected ";
-      Text (string_of_int expected);
-      Text " but got ";
-      Text (string_of_int actual)
+      Code (string_of_int expected);
+      Text " and got ";
+      Code (string_of_int actual);
+      Text "."
     ]
 end
 

--- a/lib/TypeBindings.ml
+++ b/lib/TypeBindings.ml
@@ -6,6 +6,30 @@ open Sexplib
 open Std
 open Error
 
+module Errors = struct
+  let typaram_redefinition ~param ~was ~redef =
+    austral_raise TypeError [
+      Text "The type parameter ";
+      Code (typaram_name param |> ident_string);
+      Text " cannot be bound to both ";
+      Code (type_string was);
+      Text " and ";
+      Code (type_string redef)
+    ]
+
+  let typaram_wrong_universe ~param ~ty ~expected ~actual =
+    austral_raise TypeError [
+      Text "The type parameter ";
+      Code (typaram_name param |> ident_string);
+      Text " must be ";
+      Code (universe_string expected);
+      Text " but ";
+      Code (type_string ty);
+      Text " is ";
+      Code (universe_string actual)
+    ]
+end
+
 let universe_compatible param arg =
   (* The check here is:
 
@@ -90,20 +114,19 @@ let add_binding (TypeBindings m) (tp: type_parameter) ty =
      if equal_ty ty ty' then
        TypeBindings m
      else
-       austral_raise GenericError [
-           Text "Incompatible type bindings. The parameter ";
-           Code (ident_string (typaram_name tp));
-           Text " is bound to ";
-           Code (type_string ty');
-           Text " but now we're trying to bind it to";
-           Code (type_string ty);
-           Text "."
-         ]
+       Errors.typaram_redefinition
+         ~param:tp
+         ~was:ty'
+         ~redef:ty
   | None ->
      if universe_compatible (typaram_universe tp) (type_universe ty) then
        TypeBindings (BindingsMap.add tp ty m)
      else
-       err ("Trying to add a binding to a bindings map whose universes don't match. The type parameter is `" ^ (show_type_parameter tp) ^ "` while the type is `" ^ (show_ty ty) ^ "`.")
+       Errors.typaram_wrong_universe
+         ~param:tp
+         ~ty
+         ~expected:(typaram_universe tp)
+         ~actual:(type_universe ty)
 
 (* Add multiple bindings to a bindings map. *)
 let rec add_bindings bs pairs =

--- a/lib/TypeClasses.ml
+++ b/lib/TypeClasses.ml
@@ -13,13 +13,13 @@ open Error
 
 module Errors = struct
   let broken_orphan_rule () =
-    austral_raise DeclarationError [
+    austral_raise GenericError [
       Text "Orphan rule broken: typeclass and type are both foreign."
     ]
 
   let duplicate_tyvars () =
     austral_raise DeclarationError [
-      Text "Generic instances can only use the type parameters once in the argument."
+      Text "Generic instances can only use each type parameter once in the argument."
     ]
 
   let leftovers () =
@@ -43,8 +43,8 @@ module Errors = struct
     ]
 
   let overlapping_instances () =
-    austral_raise DeclarationError [
-      Text "Instance overlap."
+    austral_raise GenericError [
+      Text "Instance overlaps."
     ]
 
   let region_arg () =
@@ -65,10 +65,11 @@ module Errors = struct
     austral_raise TypeError [
       Text "Cannot define an instance with argument ";
       Code (type_string ty);
-      Text " because it needs to be ";
+      Text " because it should belong to the ";
       Code (universe_string expected);
-      Text " but it is ";
-      Code (universe_string actual)
+      Text " universe, but it is actually in the ";
+      Code (universe_string actual);
+      Text " universe."
     ]
 end
 

--- a/lib/TypeClasses.ml
+++ b/lib/TypeClasses.ml
@@ -11,11 +11,75 @@ open EnvExtras
 open EnvUtils
 open Error
 
+module Errors = struct
+  let broken_orphan_rule () =
+    austral_raise DeclarationError [
+      Text "Orphan rule broken: typeclass and type are both foreign."
+    ]
+
+  let duplicate_tyvars () =
+    austral_raise DeclarationError [
+      Text "Generic instances can only use the type parameters once in the argument."
+    ]
+
+  let leftovers () =
+    austral_raise DeclarationError [
+      Text "The number of type parameters in the instance declaration must be the same as the number of type variables applied to the argument."
+    ]
+
+  let lone_tyvar () =
+    austral_raise DeclarationError [
+      Text "Typeclass arguments cannot be lone type parameters."
+    ]
+
+  let not_a_tyvar ty =
+    austral_raise DeclarationError [
+      Text "The type ";
+      Code (type_string ty);
+      Text " is not a type parameter, but generic instances must use either all type parameters or none of them in the argument.";
+      Break;
+      Text "Consider adding another generic parameter with universe ";
+      Code (type_universe ty |> universe_string)
+    ]
+
+  let overlapping_instances () =
+    austral_raise DeclarationError [
+      Text "Instance overlap."
+    ]
+
+  let region_arg () =
+    austral_raise DeclarationError [
+      Text "Typeclass arguments cannot be regions."
+    ]
+
+  let shadowing_typeclass_param name =
+    austral_raise DeclarationError [
+      Text "The type parameters in a generic instance declaration cannot have the same name as the type parameter in the corresponding typeclass. The colliding name is ";
+      Code (ident_string name);
+      Text ".";
+      Break;
+      Text "This is, regrettably, a load-bearing hack for https://github.com/austral/austral/issues/244. Fixing this properly would require rewriting large parts of the frontend."
+    ]
+
+  let wrong_universe ~ty ~expected ~actual =
+    austral_raise TypeError [
+      Text "Cannot define an instance with argument ";
+      Code (type_string ty);
+      Text " because it needs to be ";
+      Code (universe_string expected);
+      Text " but it is ";
+      Code (universe_string actual)
+    ]
+end
+
 let check_instance_argument_has_right_universe (universe: universe) (arg: ty): unit =
   if universe_compatible universe (type_universe arg) then
     ()
   else
-    err "While trying to define this instance, the instance's argument belongs to a universe that is not compatible with the typeclass's universe."
+    Errors.wrong_universe
+      ~ty:arg
+      ~expected:universe
+      ~actual:(type_universe arg)
 
 let check_instance_argument_has_right_shape (typarams: typarams) (arg: ty): unit =
   let is_tyvar (ty: ty): type_var =
@@ -23,20 +87,20 @@ let check_instance_argument_has_right_shape (typarams: typarams) (arg: ty): unit
     | TyVar tv ->
        tv
     | _ ->
-       err "Not a tyvar"
+       Errors.not_a_tyvar ty
   and all_distinct (tyvars: type_var list): unit =
     let names: identifier list = List.map (fun (TypeVariable (name, _, _, _)) -> name) tyvars in
     let set: IdentifierSet.t = IdentifierSet.of_list names in
     if List.length tyvars = IdentifierSet.cardinal set then
       ()
     else
-      err "All tyvars must be distinct"
+      Errors.duplicate_tyvars ()
   (* Assert the number of type parameters *)
   and no_leftovers (n: int): unit =
     if (typarams_size typarams) = n then
       ()
     else
-      err "The number of type parameters in the instance declaration must be the same as the number of type variables applied to the argument."
+      Errors.leftovers ()
   in
   match arg with
   | Unit -> ()
@@ -53,7 +117,7 @@ let check_instance_argument_has_right_shape (typarams: typarams) (arg: ty): unit
      let _ = no_leftovers 1 in
      ()
   | RegionTy _ ->
-     err "Not a type variable."
+     Errors.region_arg ()
   | ReadRef (ty, r) ->
      let _ = all_distinct [is_tyvar ty; is_tyvar r] in
      let _ = no_leftovers 2 in
@@ -63,7 +127,7 @@ let check_instance_argument_has_right_shape (typarams: typarams) (arg: ty): unit
      let _ = no_leftovers 2 in
      ()
   | TyVar _ ->
-     err "Bad shape"
+     Errors.lone_tyvar ()
   | Address ty ->
      let _ = is_tyvar ty in
      let _ = no_leftovers 1 in
@@ -151,7 +215,7 @@ let check_instance_locally_unique (instances: decl list) (argument: ty): unit =
        false
   in
   if List.exists pred instances then
-    err "Instance overlaps."
+    Errors.overlapping_instances ()
   else
     ()
 
@@ -160,7 +224,7 @@ let rec check_instance_orphan_rules (env: env) (mod_id: mod_id) (typeclass_mod_i
   and ty_local: bool = is_type_local env mod_id ty
   in
   if (not tc_local) && (not ty_local) then
-    err "Orphan rule broken: typeclass and type are both foreign."
+    Errors.broken_orphan_rule ()
   else
     ()
 
@@ -204,13 +268,7 @@ and is_type_local (env: env) (mod_id: mod_id) (ty: ty): bool =
 let check_disjoint_typarams (name: identifier) (typarams: typarams): unit =
   match get_typaram typarams name with
   | Some _ ->
-     austral_raise DeclarationError [
-         Text "The type parameters in a generic instance declaration cannot have the same name as the type parameter in the corresponding typeclass. The colliding name is ";
-         Code (ident_string name);
-         Text ".";
-         Break;
-         Text "This is, regrettably, a load-bearing hack for https://github.com/austral/austral/issues/244. Fixing this properly would require rewriting large parts of the frontend."
-       ]
+     Errors.shadowing_typeclass_param name    
   | None ->
      (* No collision *)
      ()

--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -1,0 +1,331 @@
+open Error
+open ErrorText
+open Identifier
+open Type
+
+let arithmetic_incompatible_types ~lhs ~rhs =
+  austral_raise TypeError [
+    Text "Both operands to an arithmetic expression must be compatible types. The LHS has type ";
+    Code (type_string lhs);
+    Text " but the RHS has type ";
+    Code (type_string rhs);
+    Text "."
+  ]
+
+let arithmetic_not_numeric ty =
+  austral_raise TypeError [
+    Text "Both operands of an arithmetic operator must be numeric types, but ";
+    Code (type_string ty);
+    Text " is not."
+  ]
+
+let array_indexing_disallowed ty =
+  austral_raise TypeError [
+    Text "The array indexing operator is not allowed for the type ";
+    Code (type_string ty)
+  ]
+
+let borrow_constant () =
+  austral_raise TypeError [
+    Text "Constants cannot be borrowed."
+  ]
+
+let borrow_non_linear ty =
+  austral_raise TypeError [
+    Text "Cannot borrow ";
+    Code (type_string ty);
+    Text " because it is not a linear type."
+  ]
+
+let call_non_callable ty =
+  austral_raise TypeError [
+    Text "The type ";
+    Code (type_string ty);
+    Text " is neither a function, method or function pointer, and cannot be called."
+  ]
+
+let call_wrong_arity ~name ~expected ~actual =
+  austral_raise TypeError [
+    Text "The callable ";
+    Code (ident_string name);
+    Text " expects ";
+    Text (string_of_int expected);
+    Text " argument";
+    Text (if expected = 1 then " " else "s ");
+    Text "but ";
+    Text (string_of_int actual);
+    Text (if actual = 1 then " was " else " were ");
+    Text "given."
+  ]
+
+let case_non_exhaustive () =
+  austral_raise TypeError [
+    Text "Non-exhaustive case statement."
+  ]
+
+let case_non_public () =
+  austral_raise TypeError [
+    Text "Union must be public or from the same module to be used in a case statement."
+  ]
+
+let case_non_union ty =
+  austral_raise TypeError [
+    Text "The case expression has type ";
+    Code (type_string ty);
+    Text " which is not a union type."
+  ]
+
+let case_wrong_slots () =
+  austral_raise TypeError [
+    Text "The set of slots in the case statement doesn't match the set of slots in the union definition."
+  ]
+
+let cast_different_references ~different_types ~different_regions =
+  let text = match different_types, different_regions with
+  | true, false -> [
+      Text "Cannot cast a reference to one with a different underlying type."
+    ]
+  | false, true -> [
+      Text "Cannot cast a reference to one with a different underlying region."
+    ]
+  | _ -> [
+      Text "Cannot cast to a different region"
+    ]
+  in
+  austral_raise TypeError text
+
+let cast_invalid ~target ~source =
+  austral_raise TypeError [
+    Text "Cannot cast to ";
+    Code (type_string target);
+    Text " from ";
+    Code (type_string source)
+  ]
+
+let cast_write_ref_to_non_ref () =
+  austral_raise TypeError [
+    Text "Write references can only be casted to a read reference."
+  ]
+
+let condition_not_boolean ~kind ~form ~ty =
+  austral_raise TypeError [
+    Text "The condition in ";
+    Code kind;
+    Text "-";
+    Text form;
+    Text "s should be a boolean type, but is ";
+    Code (type_string ty)
+  ]
+
+let constructor_not_named declaration =
+  austral_raise TypeError [
+    Text "Arguments to ";
+    Text declaration;
+    Text " constructor must be named."
+  ]
+
+let constructor_wrong_args declaration =
+  austral_raise TypeError [
+    Text "Arguments to ";
+    Text declaration;
+    Text " constructor have the wrong names."
+  ]
+
+let dereference_non_reference ty =
+  austral_raise TypeError [
+    Text "Only references can be dereferenced, but ";
+    Code (type_string ty);
+    Text " is not."
+  ]
+
+let destructure_non_record ty =
+  austral_raise TypeError [
+    Text "The type ";
+    Code (type_string ty);
+    Text " cannot be destructured because it is not a record."
+  ]
+
+let destructure_not_public ty =
+  austral_raise TypeError [
+    Text "The type ";
+    Code (type_string ty);
+    Text " is not a public record and so cannot be destructured."
+  ]
+
+let destructure_wrong_slots ty =
+  austral_raise TypeError [
+    Text "The set of slots mentioned differs from the set of slots in ";
+    Code (type_string ty);
+  ]
+
+let discard_linear universe =
+  austral_raise TypeError [
+    Text "Cannot discard a value in the ";
+    Code (universe_string universe);
+    Text " universe."
+  ]
+
+let expression_not_constant () =
+  austral_raise TypeError [
+    Text "The expression is not a valid constant expression."
+  ]
+
+let for_bounds_non_integral ~bound ~ty =
+  austral_raise TypeError [
+    Text "The type of the ";
+    Text bound;
+    Text " value in the loop range is ";
+    Code (type_string ty);
+    Text " which is not an integer type."
+  ]
+
+let foreign_in_safe_module () =
+  austral_raise DeclarationError [
+    Text "Can't declare a foreign function in a safe module."
+  ]
+
+let foreign_type_parameters () =
+  austral_raise DeclarationError [
+    Text "Foreign functions can't have type parameters."
+  ]
+
+let fun_pointer_named_args () =
+  austral_raise TypeError [
+    Text "You can't call a function pointer with a named argument list, because function pointers don't preserve parameter names, so we wouldn't know how to assign arguments to parameters."
+  ]
+
+let fun_invalid_pragmas () =
+  austral_raise DeclarationError [
+    Text "Only import and export pragmas are allowed inside functions."
+  ]
+
+let if_inequal ~lhs ~rhs =
+  austral_raise TypeError [
+    Text "The branches of the ";
+    Code "if";
+    Text "-expression have different types: ";
+    Code (type_string lhs);
+    Text " and ";
+    Code (type_string rhs)
+  ]
+
+let logical_operands_not_boolean ~operator ~types = match types with
+| [ty] ->
+    austral_raise TypeError [
+      Text "The operand of a ";
+      Text operator;
+      Text " operator must be a boolean expression, but it has the type ";
+      Code (type_string ty)
+    ]
+| [first; second] ->
+    austral_raise TypeError [
+      Text "Both operands of a ";
+      Text operator;
+      Text " operator must be boolean expressions, but they have types ";
+      Code (type_string first);
+      Text " and ";
+      Code (type_string second)
+    ]
+  | _ ->
+    austral_raise TypeError [
+      Text "All operands of a logical operator must be boolean expressions."
+    ]
+
+let lvalue_index () =
+  austral_raise TypeError [
+    Text "The array index operator cannot be assigned to."
+  ]
+
+let lvalue_not_free () =
+  austral_raise TypeError [
+    Text "Only values in the ";
+    Code "Free";
+    Text " universe can be assigned to."
+  ]
+
+let no_such_slot ~type_name ~slot_name =
+  austral_raise TypeError [
+    Text "The type ";
+    Code (ident_string type_name);
+    Text " has no slot with name ";
+    Code (ident_string slot_name)
+  ]
+
+let no_suitable_instance ~typeclass ~ty =
+  austral_raise TypeError [
+    Text "The typeclass ";
+    Code (ident_string typeclass);
+    Text " has no instance which matches for ";
+    Code (type_string ty)
+  ]
+
+let path_not_free ty =
+  austral_raise TypeError [
+    Text "The path ends with the type ";
+    Code (type_string ty);
+    Text " which is not in the ";
+    Code "Free";
+    Text " universe."
+  ]
+
+let path_not_public ~type_name ~slot_name =
+  austral_raise TypeError [
+    Text "The slot ";
+    Code (ident_string slot_name);
+    Text " is not publically visible in the type ";
+    Code (ident_string type_name);
+    Text " and so cannot be read."
+  ]
+
+let path_not_record ty =
+  austral_raise TypeError [
+    Text "Cannot take a path of the type ";
+    Code ty;
+    Text " because it is not a record."
+  ]
+
+let slot_wrong_type ~name ~expected ~actual =
+  austral_raise TypeError [
+    Text "The slot ";
+    Code (ident_string name);
+    Text " should have type ";
+    Code (type_string expected);
+    Text " but is declared to have type ";
+    Code (type_string actual)
+  ]
+
+let unconstrained_generic_function name =
+  austral_raise TypeError [
+    Code (ident_string name);
+    Text " is generic but unconstrained, so its type is ambiguous.";
+    Break;
+    Text "Consider clarifying its type using a cast."
+  ]
+
+let unconstrained_type_parameter ~typeclass ~typaram =
+  austral_raise TypeError [
+    Text "The type parameter ";
+    Code (ident_string typaram);
+    Text " does not implement the type class ";
+    Code (ident_string typeclass);
+    Break;
+    Text "Consider adding a constraint to the type parameter."
+  ]
+
+let unknown_callable name =
+  austral_raise TypeError [
+    Text "The function or method ";
+    Code (ident_string name);
+    Text " cannot be found.";
+    Break;
+    Text "Consider importing it if it is defined in another module."
+  ]
+
+let unknown_variable name =
+  austral_raise TypeError [
+    Text "The variable ";
+    Code (ident_string name);
+    Text " cannot be found.";
+    Break;
+    Text "Consider importing it if it is defined in another module."
+  ]

--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -233,18 +233,18 @@ let logical_operands_not_boolean ~operator ~types = match types with
 
 let lvalue_index () =
   austral_raise TypeError [
-    Text "The array index operator cannot be assigned to."
+    Text "The array index operator doesn't work in lvalues."
   ]
 
 let lvalue_not_free () =
-  austral_raise TypeError [
+  austral_raise LinearityError [
     Text "Only values in the ";
     Code "Free";
     Text " universe can be assigned to.";
     Break;
     Text "Consider using the ";
     Code "swap";
-    Text " function."
+    Text " function instead."
   ]
 
 let no_such_slot ~type_name ~slot_name =
@@ -317,12 +317,10 @@ let unconstrained_type_parameter ~typeclass ~typaram =
   ]
 
 let unknown_name ~kind ~name =
-  austral_raise TypeError [
-    Text "The ";
+  austral_raise GenericError [
+    Text "I can't find a ";
     Text kind;
-    Text " ";
+    Text " named ";
     Code (ident_string name);
-    Text " cannot be found.";
-    Break;
-    Text "Consider importing it if it is defined in another module."
+    Text "."
   ]

--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -240,7 +240,11 @@ let lvalue_not_free () =
   austral_raise TypeError [
     Text "Only values in the ";
     Code "Free";
-    Text " universe can be assigned to."
+    Text " universe can be assigned to.";
+    Break;
+    Text "Consider using the ";
+    Code "swap";
+    Text " function."
   ]
 
 let no_such_slot ~type_name ~slot_name =
@@ -312,18 +316,11 @@ let unconstrained_type_parameter ~typeclass ~typaram =
     Text "Consider adding a constraint to the type parameter."
   ]
 
-let unknown_callable name =
+let unknown_name ~kind ~name =
   austral_raise TypeError [
-    Text "The function or method ";
-    Code (ident_string name);
-    Text " cannot be found.";
-    Break;
-    Text "Consider importing it if it is defined in another module."
-  ]
-
-let unknown_variable name =
-  austral_raise TypeError [
-    Text "The variable ";
+    Text "The ";
+    Text kind;
+    Text " ";
     Code (ident_string name);
     Text " cannot be found.";
     Break;

--- a/lib/TypeMatch.ml
+++ b/lib/TypeMatch.ml
@@ -14,7 +14,7 @@ open Reporter
 open Error
 
 module Errors = struct
-  let type_mismatch _ a b =
+  let type_mismatch a b =
     austral_raise TypeError [
       Text "Expected a value of type ";
       Code (type_string a);
@@ -44,34 +44,34 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
       | Unit ->
          empty_bindings
       | _ ->
-         Errors.type_mismatch "Expected Unit, but got another type." a b)
+         Errors.type_mismatch a b)
   | Boolean ->
      (match b with
       | Boolean ->
          empty_bindings
       | _ ->
-         Errors.type_mismatch "Expected Boolean, but got another type." a b)
+         Errors.type_mismatch a b)
   | Integer (s, w) ->
      (match b with
       | Integer (s', w') ->
          if (s = s') && (w = w') then
            empty_bindings
          else
-           Errors.type_mismatch "Integer types don't match" a b
+           Errors.type_mismatch a b
       | _ ->
-         Errors.type_mismatch "Expected an integer, but got another type." a b)
+         Errors.type_mismatch a b)
   | SingleFloat ->
      (match b with
       | SingleFloat ->
          empty_bindings
       | _ ->
-         Errors.type_mismatch "Expected SingleFloat, but got another type." a b)
+         Errors.type_mismatch a b)
   | DoubleFloat ->
      (match b with
       | DoubleFloat ->
          empty_bindings
       | _ ->
-         Errors.type_mismatch "Expected DoubleFloat, but got another type." a b)
+         Errors.type_mismatch a b)
   | NamedType (n, args, _) ->
      (match b with
       | NamedType (n', args', _) ->
@@ -79,24 +79,24 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
          if n = n' then
            match_type_list ctx args args'
          else
-           Errors.type_mismatch "Type mismatch" a b
+           Errors.type_mismatch a b
       | _ ->
-         Errors.type_mismatch "Expected a named type, but got something else." a b)
+         Errors.type_mismatch a b)
   | StaticArray t ->
      (match b with
       | StaticArray t' ->
          match_type ctx t t'
       | _ ->
-         Errors.type_mismatch "Expected an array, but got another type." a b)
+         Errors.type_mismatch a b)
   | RegionTy r ->
      (match b with
       | RegionTy r' ->
          if r = r' then
            empty_bindings
          else
-           Errors.type_mismatch "Region type mismatch" a b
+           Errors.type_mismatch a b
       | _ ->
-         Errors.type_mismatch "Expected a region, but got another type." a b)
+         Errors.type_mismatch a b)
   | ReadRef (t, r) ->
      (match b with
       | ReadRef (t', r') ->
@@ -104,7 +104,7 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
          let bindings' = match_type ctx r r' in
          merge_bindings bindings bindings'
       | _ ->
-         Errors.type_mismatch "Expected a read reference, but got another type." a b)
+         Errors.type_mismatch a b)
   | WriteRef (t, r) ->
      (match b with
       | WriteRef (t', r') ->
@@ -112,7 +112,7 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
          let bindings' = match_type ctx r r' in
          merge_bindings bindings bindings'
       | _ ->
-         Errors.type_mismatch "Expected a write reference, but got another type." a b)
+         Errors.type_mismatch a b)
   | TyVar tyvar ->
      match_type_var ctx tyvar b
   | Address t ->
@@ -120,19 +120,19 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
       | Address t' ->
          match_type ctx t t'
       | _ ->
-         Errors.type_mismatch "Expected an Address, but got another type." a b)
+         Errors.type_mismatch a b)
   | Pointer t ->
      (match b with
       | Pointer t' ->
          match_type ctx t t'
       | _ ->
-         Errors.type_mismatch "Expected a Pointer, but got another type." a b)
+         Errors.type_mismatch a b)
   | FnPtr (args, rt) ->
      (match b with
       | FnPtr (args', rt') ->
          match_type_list ctx (rt :: args) (rt' :: args')
       | _ ->
-         Errors.type_mismatch "Expected a function pointer, but got another type." a b)
+         Errors.type_mismatch a b)
   | MonoTy _ ->
      err "match_type called with MonoTy argument"
 

--- a/lib/TypeMatch.ml
+++ b/lib/TypeMatch.ml
@@ -13,15 +13,21 @@ open EnvExtras
 open Reporter
 open Error
 
-let type_mismatch _ a b =
-  austral_raise TypeError
-    [
+module Errors = struct
+  let type_mismatch _ a b =
+    austral_raise TypeError [
       Text "Expected a value of type ";
       Code (type_string a);
       Text ", but got a value of type ";
       Code (type_string b);
       Text "."
     ]
+
+  let unsatisfied_constraint () =
+    austral_raise TypeError [
+      Text "Type constraint not satisfied."
+    ]
+end
 
 type ctx = env * module_name
 
@@ -38,34 +44,34 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
       | Unit ->
          empty_bindings
       | _ ->
-         type_mismatch "Expected Unit, but got another type." a b)
+         Errors.type_mismatch "Expected Unit, but got another type." a b)
   | Boolean ->
      (match b with
       | Boolean ->
          empty_bindings
       | _ ->
-         type_mismatch "Expected Boolean, but got another type." a b)
+         Errors.type_mismatch "Expected Boolean, but got another type." a b)
   | Integer (s, w) ->
      (match b with
       | Integer (s', w') ->
          if (s = s') && (w = w') then
            empty_bindings
          else
-           type_mismatch "Integer types don't match" a b
+           Errors.type_mismatch "Integer types don't match" a b
       | _ ->
-         type_mismatch "Expected an integer, but got another type." a b)
+         Errors.type_mismatch "Expected an integer, but got another type." a b)
   | SingleFloat ->
      (match b with
       | SingleFloat ->
          empty_bindings
       | _ ->
-         type_mismatch "Expected SingleFloat, but got another type." a b)
+         Errors.type_mismatch "Expected SingleFloat, but got another type." a b)
   | DoubleFloat ->
      (match b with
       | DoubleFloat ->
          empty_bindings
       | _ ->
-         type_mismatch "Expected DoubleFloat, but got another type." a b)
+         Errors.type_mismatch "Expected DoubleFloat, but got another type." a b)
   | NamedType (n, args, _) ->
      (match b with
       | NamedType (n', args', _) ->
@@ -73,24 +79,24 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
          if n = n' then
            match_type_list ctx args args'
          else
-           type_mismatch "Type mismatch" a b
+           Errors.type_mismatch "Type mismatch" a b
       | _ ->
-         type_mismatch "Expected a named type, but got something else." a b)
+         Errors.type_mismatch "Expected a named type, but got something else." a b)
   | StaticArray t ->
      (match b with
       | StaticArray t' ->
          match_type ctx t t'
       | _ ->
-         type_mismatch "Expected an array, but got another type." a b)
+         Errors.type_mismatch "Expected an array, but got another type." a b)
   | RegionTy r ->
      (match b with
       | RegionTy r' ->
          if r = r' then
            empty_bindings
          else
-           type_mismatch "Region type mismatch" a b
+           Errors.type_mismatch "Region type mismatch" a b
       | _ ->
-         type_mismatch "Expected a region, but got another type." a b)
+         Errors.type_mismatch "Expected a region, but got another type." a b)
   | ReadRef (t, r) ->
      (match b with
       | ReadRef (t', r') ->
@@ -98,7 +104,7 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
          let bindings' = match_type ctx r r' in
          merge_bindings bindings bindings'
       | _ ->
-         type_mismatch "Expected a read reference, but got another type." a b)
+         Errors.type_mismatch "Expected a read reference, but got another type." a b)
   | WriteRef (t, r) ->
      (match b with
       | WriteRef (t', r') ->
@@ -106,7 +112,7 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
          let bindings' = match_type ctx r r' in
          merge_bindings bindings bindings'
       | _ ->
-         type_mismatch "Expected a write reference, but got another type." a b)
+         Errors.type_mismatch "Expected a write reference, but got another type." a b)
   | TyVar tyvar ->
      match_type_var ctx tyvar b
   | Address t ->
@@ -114,19 +120,19 @@ let rec match_type (ctx: ctx) (a: ty) (b: ty): type_bindings =
       | Address t' ->
          match_type ctx t t'
       | _ ->
-         type_mismatch "Expected an Address, but got another type." a b)
+         Errors.type_mismatch "Expected an Address, but got another type." a b)
   | Pointer t ->
      (match b with
       | Pointer t' ->
          match_type ctx t t'
       | _ ->
-         type_mismatch "Expected a Pointer, but got another type." a b)
+         Errors.type_mismatch "Expected a Pointer, but got another type." a b)
   | FnPtr (args, rt) ->
      (match b with
       | FnPtr (args', rt') ->
          match_type_list ctx (rt :: args) (rt' :: args')
       | _ ->
-         type_mismatch "Expected a function pointer, but got another type." a b)
+         Errors.type_mismatch "Expected a function pointer, but got another type." a b)
   | MonoTy _ ->
      err "match_type called with MonoTy argument"
 
@@ -187,7 +193,7 @@ and try_constraint (ctx: ctx) (ty: ty) (typeclass_name: sident): unit =
       | Some _ ->
          ()
       | None ->
-         err "Type constraint not satisfied.")
+         Errors.unsatisfied_constraint ())
   | Some _ ->
      internal_err "Type parameter constraint refers to a declaration which is not a typeclass."
   | None ->

--- a/lib/TypeParameters.ml
+++ b/lib/TypeParameters.ml
@@ -13,10 +13,10 @@ module Errors = struct
         Code (typaram_name param |> ident_string)
       ]
     | None -> [
-        Text "Multiple type parameters have the same name";
+        Text "Multiple type parameters have the same name.";
       ]
     in
-    austral_raise DeclarationError text
+    austral_raise GenericError text
 end
 
 type typarams = TyParams of type_parameter list

--- a/lib/TypeParser.ml
+++ b/lib/TypeParser.ml
@@ -37,7 +37,7 @@ module Errors = struct
   let unresolved_type name =
     austral_raise TypeError [
       Text "Unable to find a type with the name ";
-      Code (original_name name |> ident_string);
+      Code (ident_string name);
       Text ".";
       Break;
       Text "Consider importing it if it is defined in another module."
@@ -311,7 +311,7 @@ and parse_user_defined_type (env: env) (sigs: type_signature list) (name: qident
   | Some ts ->
      parse_user_defined_type' ts name args
   | None ->
-     Errors.unresolved_type name
+     Errors.unresolved_type (original_name name)
 
 and parse_user_defined_type' (ts: type_signature) (name: qident) (args: ty list): ty =
   let (TypeSignature (_, ts_params, declared_universe)) = ts in

--- a/lib/TypeParser.ml
+++ b/lib/TypeParser.ml
@@ -48,20 +48,19 @@ module Errors = struct
       Text "The type ";
       Code typename;
       Text " expects ";
-      Text (string_of_int expected);
-      Text " type argument";
-      Text (if expected = 1 then "" else "s")
+      Code (string_of_int expected);
+      Text " type arguments";
     ]
     in
     let text = text @ match actual with
     | Some actual -> [
-        Text ", but was given ";
-        Text (string_of_int actual);
-        Text "."
+        Text ", but I only found ";
+        Code (string_of_int actual);
+        Text " arguments."
       ]
     | None -> [Text "."]
     in
-    austral_raise TypeError text
+    austral_raise GenericError text
 end
 
 let decl_type_signature (decl: decl): type_signature option =

--- a/lib/TypeParser.ml
+++ b/lib/TypeParser.ml
@@ -12,6 +12,58 @@ open EnvTypes
 open Error
 open ErrorText
 
+module Errors = struct
+  let function_pointer_no_args () =
+    austral_raise ParseError [
+      Text "Function pointer type specifier must have at least one argument."
+    ]
+
+  let not_a_region typename =
+    austral_raise TypeError [
+      Code typename;
+      Text " takes as second argument a region, but was given a type."
+    ]
+
+  let typaram_wrong_universe ~param ~expected ~actual =
+    austral_raise TypeError [
+      Text "The type parameter ";
+      Code (typaram_name param |> ident_string);
+      Text " is expected to be ";
+      Code (universe_string expected);
+      Text " but the supplied argument is ";
+      Code (universe_string actual)
+    ]
+
+  let unresolved_type name =
+    austral_raise TypeError [
+      Text "Unable to find a type with the name ";
+      Code (original_name name |> ident_string);
+      Text ".";
+      Break;
+      Text "Consider importing it if it is defined in another module."
+    ]
+
+  let wrong_arity ~typename ~expected ~actual =
+    let text = [
+      Text "The type ";
+      Code typename;
+      Text " expects ";
+      Text (string_of_int expected);
+      Text " type argument";
+      Text (if expected = 1 then "" else "s")
+    ]
+    in
+    let text = text @ match actual with
+    | Some actual -> [
+        Text ", but was given ";
+        Text (string_of_int actual);
+        Text "."
+      ]
+    | None -> [Text "."]
+    in
+    austral_raise TypeError text
+end
+
 let decl_type_signature (decl: decl): type_signature option =
   match decl with
   | Constant _ ->
@@ -34,7 +86,7 @@ let decl_type_signature (decl: decl): type_signature option =
 let parse_function_pointer (args: ty list): ty =
   match args with
   | [] ->
-     err "Function pointer type specifier must have at least one argument."
+     Errors.function_pointer_no_args ()
   | [r] ->
      FnPtr ([], r)
   | _ ->
@@ -48,14 +100,14 @@ let parse_built_in_type (name: qident) (args: ty list): ty option =
     | [ty] ->
        Some (Address ty)
     | _ ->
-       err "Invalid Address type specifier."
+       Errors.wrong_arity ~typename:"Address" ~expected:1 ~actual:None
   else
     if is_pointer_type name then
       match args with
       | [ty] ->
          Some (Pointer ty)
       | _ ->
-         err "Invalid Pointer type specifier."
+         Errors.wrong_arity ~typename:"Pointer" ~expected:1 ~actual:None
     else
       let name_str: string = ident_string (original_name name) in
       match name_str with
@@ -94,7 +146,10 @@ let parse_built_in_type (name: qident) (args: ty list): ty option =
           | [ty] ->
              Some (StaticArray ty)
           | _ ->
-             err "Invalid FixedArray type specifier.")
+             Errors.wrong_arity
+               ~typename:"FixedArray"
+               ~expected:1
+               ~actual:None)
       | "Reference" ->
          (match args with
           | [ty; ty'] ->
@@ -102,9 +157,12 @@ let parse_built_in_type (name: qident) (args: ty list): ty option =
              if (u = RegionUniverse) then
                Some (ReadRef (ty, ty'))
              else
-               err "Reference error: Not a region"
+               Errors.not_a_region "Reference"
           | _ ->
-             err "Invalid Reference type specifier.")
+             Errors.wrong_arity
+               ~typename:"Reference"
+               ~expected:2
+               ~actual:None)
       | "WriteReference" ->
          (match args with
           | [ty; ty'] ->
@@ -112,9 +170,12 @@ let parse_built_in_type (name: qident) (args: ty list): ty option =
              if (u' = RegionUniverse) then
                Some (WriteRef (ty, ty'))
              else
-               err "WriteReference error: Not a region"
+               Errors.not_a_region "WriteReference"
           | _ ->
-             err "Invalid WriteReference type specifier.")
+             Errors.wrong_arity
+               ~typename:"WriteReference"
+               ~expected:2
+               ~actual:None)
       | "Fn" ->
          Some (parse_function_pointer args)
       | _ ->
@@ -250,7 +311,7 @@ and parse_user_defined_type (env: env) (sigs: type_signature list) (name: qident
   | Some ts ->
      parse_user_defined_type' ts name args
   | None ->
-     err ("No user defined type with name: " ^ (qident_debug_name name))
+     Errors.unresolved_type name
 
 and parse_user_defined_type' (ts: type_signature) (name: qident) (args: ty list): ty =
   let (TypeSignature (_, ts_params, declared_universe)) = ts in
@@ -271,15 +332,10 @@ and check_param_arity_matches (params: typarams) (args: ty list) (ty_name: qiden
   if expected = got then
     ()
   else
-    austral_raise GenericError [
-        Text "The type ";
-        Code (ident_string (original_name ty_name));
-        Text " expects ";
-        Code (string_of_int expected);
-        Text " type arguments, but I only found ";
-        Code (string_of_int got);
-        Text " arguments."
-      ]
+    Errors.wrong_arity
+      ~typename:(original_name ty_name |> ident_string)
+      ~expected
+      ~actual:(Some got)
 
 and check_universes_match (params: typarams) (args: ty list): unit =
   let _ = List.map2 check_universes_match' (typarams_as_list params) args in ()
@@ -290,10 +346,7 @@ and check_universes_match' (tp: type_parameter) (arg: ty): unit =
   if universe_compatible param_u arg_u then
     ()
   else
-    err ("Type parser: Universe mismatch: parameter universe is "
-         ^ (universe_string param_u)
-         ^ ", argument universe is "
-         ^ (universe_string arg_u))
+    Errors.typaram_wrong_universe ~param:tp ~expected:param_u ~actual:arg_u
 
 and universe_compatible param arg =
   (* The check here is:

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -76,7 +76,9 @@ let rec augment_expr (module_name: module_name) (env: env) (rm: region_map) (typ
                   | VarLocal ->
                      TLocalVar ((original_name name), ty))
               | None ->
-                 Errors.unknown_variable (original_name name)))
+                 Errors.unknown_name
+                   ~kind:"variable"
+                   ~name:(original_name name)))
       | FunctionCall (name, args) ->
          augment_call module_name env lexenv asserted_ty name (augment_arglist module_name env rm typarams lexenv None args)
       | ArithmeticExpression (op, lhs, rhs) ->
@@ -314,7 +316,9 @@ let rec augment_expr (module_name: module_name) (env: env) (rm: region_map) (typ
                  in
                  TBorrowExpr (mode, name, reg, ty))
           | None ->
-             Errors.unknown_variable (original_name name)))
+             Errors.unknown_name
+               ~kind:"variable"
+               ~name:(original_name name)))
 
 and get_path_ty_from_elems (elems: typed_path_elem list): ty =
   assert ((List.length elems) > 0);
@@ -465,7 +469,9 @@ and augment_call (module_name: module_name) (env: env) (lexenv: lexenv) (asserte
       | Some callable ->
          augment_callable module_name env name callable asserted_ty args
       | None ->
-         Errors.unknown_callable (original_name name))
+         Errors.unknown_name
+           ~kind:"callable"
+           ~name:(original_name name))
 
 and augment_fptr_call (module_name: module_name) (env: env) (name: identifier) (fn_ptr_ty: ty) (asserted_ty: ty option) (args: typed_arglist): texpr =
   (* Because function pointers don't preserve value parameter names, we can't
@@ -972,7 +978,7 @@ let rec augment_stmt (ctx: stmt_ctx) (stmt: astmt): tstmt =
                      else
                        Errors.lvalue_not_free ())
               | None ->
-                 Errors.unknown_variable var))
+                 Errors.unknown_name ~kind:"variable" ~name:var))
       | AIf (span, c, t, f) ->
          adorn_error_with_span span
            (fun _ ->
@@ -1076,7 +1082,7 @@ let rec augment_stmt (ctx: stmt_ctx) (stmt: astmt): tstmt =
                  else
                    Errors.borrow_non_linear orig_ty
               | None ->
-                 Errors.unknown_variable original))
+                 Errors.unknown_name ~kind:"variable" ~name:original))
       | ABlock (span, f, r) ->
          let a = augment_stmt ctx f in
          let b = augment_stmt ctx r in

--- a/test-programs/suites/003-record/002-free-record-has-linear/austral-stderr.txt
+++ b/test-programs/suites/003-record/002-free-record-has-linear/austral-stderr.txt
@@ -1,10 +1,10 @@
 Error:
-  Title: Generic Error
+  Title: Linearity Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    Record was declared to belong to the Free universe, but it contains a type that beloings to the Linear universe.
+    `Bar` was declared to belong to the `Free` universe, but it contains a type that belongs to the `Linear` universe.
   Code:
     [no span available]

--- a/test-programs/suites/003-record/003-free-record-linear-param/austral-stderr.txt
+++ b/test-programs/suites/003-record/003-free-record-linear-param/austral-stderr.txt
@@ -1,10 +1,10 @@
 Error:
-  Title: Generic Error
+  Title: Linearity Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    This type was declared to be in the Free universe, but it has a type parameter in the Type universe.
+    `Foo` was declared to belong to the `Free` universe, but it has a type parameter that belongs to the `Type` universe.
   Code:
     [no span available]

--- a/test-programs/suites/003-record/004-record-in-region/austral-stderr.txt
+++ b/test-programs/suites/003-record/004-record-in-region/austral-stderr.txt
@@ -1,10 +1,12 @@
 Error:
-  Title: Generic Error
+  Title: Declaration Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    Trying to define a record in the Region universe. Regions are distinct from types.
+    The record `Foo` was declared to belong to the `Region` universe, but regions are distinct from types.
+
+    Consider using one of `Type`, `Linear`, or `Free` instead.
   Code:
     [no span available]

--- a/test-programs/suites/004-union/002-free-union-has-linear/austral-stderr.txt
+++ b/test-programs/suites/004-union/002-free-union-has-linear/austral-stderr.txt
@@ -1,10 +1,10 @@
 Error:
-  Title: Generic Error
+  Title: Linearity Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    Union was declared to belong to the Free universe, but it contains a type that beloings to the Linear universe.
+    `B` was declared to belong to the `Free` universe, but it contains a type that belongs to the `Linear` universe.
   Code:
     [no span available]

--- a/test-programs/suites/004-union/003-free-union-linear-param/austral-stderr.txt
+++ b/test-programs/suites/004-union/003-free-union-linear-param/austral-stderr.txt
@@ -1,10 +1,10 @@
 Error:
-  Title: Generic Error
+  Title: Linearity Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    This type was declared to be in the Free universe, but it has a type parameter in the Type universe.
+    `Foo` was declared to belong to the `Free` universe, but it has a type parameter that belongs to the `Type` universe.
   Code:
     [no span available]

--- a/test-programs/suites/004-union/004-union-in-region/austral-stderr.txt
+++ b/test-programs/suites/004-union/004-union-in-region/austral-stderr.txt
@@ -1,10 +1,12 @@
 Error:
-  Title: Generic Error
+  Title: Declaration Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    Trying to define a union in the Region universe. Regions are distinct from types.
+    The union `Foo` was declared to belong to the `Region` universe, but regions are distinct from types.
+
+    Consider using one of `Type`, `Linear`, or `Free` instead.
   Code:
     [no span available]

--- a/test-programs/suites/006-linearity/013-no-assignment/austral-stderr.txt
+++ b/test-programs/suites/006-linearity/013-no-assignment/austral-stderr.txt
@@ -1,5 +1,5 @@
 Error:
-  Title: Generic Error
+  Title: Linearity Error
   Module:
     Test
   Location:
@@ -7,7 +7,9 @@ Error:
     From: line 6, column 8
     To: line 6, column 21
   Description:
-    L-values must end in the free universe
+    Only values in the `Free` universe can be assigned to.
+
+    Consider using the `swap` function instead.
   Code:
     4 |     function main(): ExitCode is
     5 |         let foo: Foo := Foo();

--- a/test-programs/suites/008-typeclasses/002-region-param/austral-stderr.txt
+++ b/test-programs/suites/008-typeclasses/002-region-param/austral-stderr.txt
@@ -1,10 +1,12 @@
 Error:
-  Title: Generic Error
+  Title: Declaration Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    The type class parameter must have a universe in {Type, Linear, Free}.
+    The parameter for the typeclass `AcceptsRegion` cannot be declared to be in the `Region` universe, because regions are distinct from types.
+
+    Consider using one of `Type`, `Linear`, or `Free` instead.
   Code:
     [no span available]

--- a/test-programs/suites/008-typeclasses/003-expect-linear/austral-stderr.txt
+++ b/test-programs/suites/008-typeclasses/003-expect-linear/austral-stderr.txt
@@ -1,10 +1,10 @@
 Error:
-  Title: Generic Error
+  Title: Type Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    While trying to define this instance, the instance's argument belongs to a universe that is not compatible with the typeclass's universe.
+    Cannot define an instance with argument `Nat8` because it should belong to the `Linear` universe, but it is actually in the `Free` universe.
   Code:
     [no span available]

--- a/test-programs/suites/008-typeclasses/004-expect-free/austral-stderr.txt
+++ b/test-programs/suites/008-typeclasses/004-expect-free/austral-stderr.txt
@@ -1,10 +1,10 @@
 Error:
-  Title: Generic Error
+  Title: Type Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    While trying to define this instance, the instance's argument belongs to a universe that is not compatible with the typeclass's universe.
+    Cannot define an instance with argument `Test::Foo: Linear` because it should belong to the `Free` universe, but it is actually in the `Linear` universe.
   Code:
     [no span available]

--- a/test-programs/suites/008-typeclasses/005-duplicate-tyvar/austral-stderr.txt
+++ b/test-programs/suites/008-typeclasses/005-duplicate-tyvar/austral-stderr.txt
@@ -1,10 +1,10 @@
 Error:
-  Title: Generic Error
+  Title: Declaration Error
   Module:
     Test
   Location:
     [no span available]
   Description:
-    All tyvars must be distinct
+    Generic instances can only use each type parameter once in the argument.
   Code:
     [no span available]

--- a/test-programs/suites/008-typeclasses/006-unused-tyvar/austral-stderr.txt
+++ b/test-programs/suites/008-typeclasses/006-unused-tyvar/austral-stderr.txt
@@ -1,5 +1,5 @@
 Error:
-  Title: Generic Error
+  Title: Declaration Error
   Module:
     Test
   Location:

--- a/test-programs/suites/008-typeclasses/011-unconstrained-typaram/austral-stderr.txt
+++ b/test-programs/suites/008-typeclasses/011-unconstrained-typaram/austral-stderr.txt
@@ -1,5 +1,5 @@
 Error:
-  Title: Generic Error
+  Title: Type Error
   Module:
     Test
   Location:
@@ -7,7 +7,9 @@ Error:
     From: line 14, column 8
     To: line 14, column 22
   Description:
-    Type parameter does not implement typeclass.
+    The type parameter `T` does not implement the type class `Acceptable`
+
+    Consider adding a constraint to the type parameter.
   Code:
     12 |     generic [T: Free]
     13 |     function Foo(value: T): Unit is

--- a/test-programs/suites/008-typeclasses/016-private-instance/austral-stderr.txt
+++ b/test-programs/suites/008-typeclasses/016-private-instance/austral-stderr.txt
@@ -1,5 +1,5 @@
 Error:
-  Title: Generic Error
+  Title: Type Error
   Module:
     Test
   Location:
@@ -7,7 +7,7 @@ Error:
     From: line 5, column 8
     To: line 5, column 33
   Description:
-    Typeclass resolution failed. Dispatch type: Bool
+    The typeclass `Foo` has no instance which matches for `Bool`
   Code:
     3 | module body Test is
     4 |     function main(): ExitCode is

--- a/test-programs/suites/011-bugs/github-422/README.md
+++ b/test-programs/suites/011-bugs/github-422/README.md
@@ -1,0 +1,1 @@
+Regression test for [GitHub issue #422](https://github.com/austral/austral/issues/422).

--- a/test-programs/suites/011-bugs/github-422/Test.aum
+++ b/test-programs/suites/011-bugs/github-422/Test.aum
@@ -1,0 +1,6 @@
+module body Test is
+  function main(): ExitCode is
+    return ExitSuccess();
+  end;
+end module body.
+-- test


### PR DESCRIPTION
This reduces the total number of calls to `Error.err` from around 190 to a bit less than 50, replacing them with appropriate calls to `austral_raise`.

Although I've tried to not be too radical with the changes, I found that doing a simple "search and replace" ended up making the code quite noisy, especially in places where there are many longer error messages. As such, I ended up creating submodules named `Errors` in every module where an error is emitted. These submodules contain functions like `Errors.unknown_typeclass : identifier -> 'a` which take care of formatting and eventually raising the error.

For some of the updated calls, I also added some more information and tried to make the error messages a bit clearer and more helpful. Because some of the expected stderrs in the test suite had to be updated because of that, I only did so when I felt there was a significant enough improvement. None of the tests themselves have changed.

The remaining `err`s were left alone either because I was unable to trigger them and/or because I believed they should be `internal_err`s instead.

Finally, I have to the best of my knowledge only touched the error reporting stuff, so the compiler logic itself should be unaffected.