### PR TITLE
Allow assigning to a linear variable once it's been consumed

### DIFF
--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -555,8 +555,7 @@ let rec check_stmt (tbl: state_tbl) (depth: loop_depth) (stmt: tstmt): state_tbl
                      Text " because it is not yet consumed."
                    ]
               | Consumed ->
-                 let tbl: state_tbl = update_tbl tbl var_name Unconsumed
-                 in
+                 let tbl: state_tbl = update_tbl tbl var_name Unconsumed in
                  tbl)
           | _ ->
              (* Assigning to a path. *)

--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -242,17 +242,6 @@ let lvalue_index () =
     Text "The array index operator doesn't work in lvalues."
   ]
 
-let lvalue_not_free () =
-  austral_raise LinearityError [
-    Text "Only values in the ";
-    Code "Free";
-    Text " universe can be assigned to.";
-    Break;
-    Text "Consider using the ";
-    Code "swap";
-    Text " function instead."
-  ]
-
 let no_such_slot ~type_name ~slot_name =
   austral_raise TypeError [
     Text "The type ";

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -199,29 +199,15 @@ let rec augment_stmt (ctx: stmt_ctx) (stmt: astmt): tstmt =
                   | [] ->
                      (* Assigning to a variable. *)
                      let value = augment_expr module_name env rm typarams lexenv None value in
-                     let universe = type_universe (get_type value) in
-                     if universe = FreeUniverse then
-                       let _ = match_type_with_value (env, module_name) var_ty value in
-                       TAssign (span, TypedLValue (var, []), value)
-                     else
-                       Errors.lvalue_not_free ()
+                     let _ = match_type_with_value (env, module_name) var_ty value in
+                     TAssign (span, TypedLValue (var, []), value)
                   | elems ->
                      (* Assigning to a path. *)
                      let elems = augment_lvalue_path env module_name rm typarams lexenv var_ty elems in
                      let value = augment_expr module_name env rm typarams lexenv None value in
                      let ty = get_path_ty_from_elems elems in
                      let _ = match_type_with_value (env, module_name) ty value in
-                     let path = TPath {
-                                    head = value;
-                                    elems = elems;
-                                    ty = ty
-                                  }
-                     in
-                     let universe = type_universe (get_type path) in
-                     if universe = FreeUniverse then
-                       TAssign (span, TypedLValue (var, elems), value)
-                     else
-                       Errors.lvalue_not_free ())
+                     TAssign (span, TypedLValue (var, elems), value))
               | None ->
                  Errors.unknown_name ~kind:"variable" ~name:var))
       | AIf (span, c, t, f) ->

--- a/test-programs/suites/006-linearity/013-no-assignment/Test.aum
+++ b/test-programs/suites/006-linearity/013-no-assignment/Test.aum
@@ -4,7 +4,7 @@ module body Test is
     function main(): ExitCode is
         let foo: Foo := Foo();
         foo := Foo();
-        let {} := r;
+        let {} := foo;
         return ExitSuccess();
     end;
 end module body.

--- a/test-programs/suites/006-linearity/013-no-assignment/austral-stderr.txt
+++ b/test-programs/suites/006-linearity/013-no-assignment/austral-stderr.txt
@@ -3,16 +3,8 @@ Error:
   Module:
     Test
   Location:
-    Filename: 'test-programs/suites/006-linearity/013-no-assignment/Test.aum'
-    From: line 6, column 8
-    To: line 6, column 21
+    [no span available]
   Description:
-    Only values in the `Free` universe can be assigned to.
-
-    Consider using the `swap` function instead.
+    Cannot assign to the variable `foo` because it is not yet consumed.
   Code:
-    4 |     function main(): ExitCode is
-    5 |         let foo: Foo := Foo();
-    6 |         foo := Foo();
-    7 |         let {} := r;
-    8 |         return ExitSuccess();
+    [no span available]

--- a/test-programs/suites/006-linearity/014-assign-after-consume/README.md
+++ b/test-programs/suites/006-linearity/014-assign-after-consume/README.md
@@ -1,0 +1,1 @@
+Test we can assign to a linear variable after it has been consumed.

--- a/test-programs/suites/006-linearity/014-assign-after-consume/Test.aum
+++ b/test-programs/suites/006-linearity/014-assign-after-consume/Test.aum
@@ -1,0 +1,12 @@
+module body Test is
+    record Foo: Linear is end;
+
+    function main(): ExitCode is
+        let foo: Foo := Foo();
+        foo := Foo(); -- Assign
+        let {} := r;  -- Consume
+        foo := Foo(); -- Assign
+        let {} := r;  -- Consume
+        return ExitSuccess();
+    end;
+end module body.

--- a/test-programs/suites/006-linearity/014-assign-after-consume/Test.aum
+++ b/test-programs/suites/006-linearity/014-assign-after-consume/Test.aum
@@ -3,7 +3,6 @@ module body Test is
 
     function main(): ExitCode is
         let foo: Foo := Foo();
-        foo := Foo();   -- Assign
         let {} := foo;  -- Consume
         foo := Foo();   -- Assign
         let {} := foo;  -- Consume

--- a/test-programs/suites/006-linearity/014-assign-after-consume/Test.aum
+++ b/test-programs/suites/006-linearity/014-assign-after-consume/Test.aum
@@ -3,10 +3,10 @@ module body Test is
 
     function main(): ExitCode is
         let foo: Foo := Foo();
-        foo := Foo(); -- Assign
-        let {} := r;  -- Consume
-        foo := Foo(); -- Assign
-        let {} := r;  -- Consume
+        foo := Foo();   -- Assign
+        let {} := foo;  -- Consume
+        foo := Foo();   -- Assign
+        let {} := foo;  -- Consume
         return ExitSuccess();
     end;
 end module body.


### PR DESCRIPTION
Fix #459 