### PR TITLE
Allow consuming linear variables in loops if you put them back

### DIFF
--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -115,7 +115,7 @@ let mark_pending (tbl: state_tbl) (name: identifier): state_tbl =
   if is_pending tbl name then
     internal_err "Identifier twice marked pending."
   else
-    StateTable (rows, pending)
+    StateTable (rows, name :: pending)
 
 let remove_pending (tbl: state_tbl) (name: identifier): state_tbl =
   if not (is_pending tbl name) then

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -100,6 +100,13 @@ let rec remove_entries (tbl: state_tbl) (names: identifier list): state_tbl =
   | [] ->
      tbl
 
+let mark_owed (tbl: state_tbl) (name: identifier): state_tbl =
+  let (StateTable (rows, owed)) = tbl in
+  if List.exists (fun elem -> equal_identifier name elem) owed then
+    internal_err "Identifier twice marked owed."
+  else
+    StateTable (rows, owed)
+
 let tbl_to_list (tbl: state_tbl): (identifier * loop_depth * var_state) list =
   table_rows tbl
 

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -604,7 +604,10 @@ let rec check_stmt (tbl: state_tbl) (depth: loop_depth) (stmt: tstmt): state_tbl
                    ]
               | Consumed ->
                  let tbl: state_tbl = update_tbl tbl var_name Unconsumed in
-                 tbl)
+                 if is_pending tbl var_name then
+                   remove_pending tbl var_name
+                 else
+                   tbl)
           | _ ->
              (* Assigning to a path. *)
              let tbl: state_tbl = check_expr tbl depth expr in

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -442,16 +442,13 @@ let rec check_var_in_expr (tbl: state_tbl) (depth: loop_depth) (name: identifier
      error_already_consumed name
 
 and consume_once (tbl: state_tbl) (depth: loop_depth) (name: identifier): state_tbl =
-   if depth = get_loop_depth tbl name then
-      update_tbl tbl name Consumed
-   else
-      austral_raise LinearityError [
-         Text "The variable ";
-         Code (ident_string name);
-         Text " was defined outside a loop, but you're trying to consume it inside a loop.";
-         Break;
-         Text "This is not allowed because it could be consumed zero times or more than once."
-       ]
+  let tbl: state_tbl = update_tbl tbl name Consumed in
+  if depth <> get_loop_depth tbl name then
+    (* Consumed inside a loop, so mark it as pending. *)
+    mark_pending tbl name
+  else
+    (* Nothing else to do. *)
+    tbl
 
 and error_borrowed_mutably_and_used (name: identifier) =
    austral_raise LinearityError [

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -118,6 +118,10 @@ let remove_pending (tbl: state_tbl) (name: identifier): state_tbl =
 let tbl_to_list (tbl: state_tbl): (identifier * loop_depth * var_state) list =
   table_rows tbl
 
+let get_pending (tbl: state_tbl): identifier list =
+  let (StateTable (_, pending)) = tbl in
+  pending
+
 type appearances = {
     consumed: int;
     read: int;

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -107,6 +107,14 @@ let mark_pending (tbl: state_tbl) (name: identifier): state_tbl =
   else
     StateTable (rows, pending)
 
+let remove_pending (tbl: state_tbl) (name: identifier): state_tbl =
+  let (StateTable (rows, pending)) = tbl in
+  let pending' = List.filter (fun elem -> not (equal_identifier name elem)) pending in
+  if (List.length pending') = (List.length pending) then
+    internal_err "Tried to remove_pending an identifier not on the list of pending variables."
+  else
+    StateTable (rows, pending')
+
 let tbl_to_list (tbl: state_tbl): (identifier * loop_depth * var_state) list =
   table_rows tbl
 

--- a/lib/LinearityCheck.mli
+++ b/lib/LinearityCheck.mli
@@ -52,6 +52,9 @@ val remove_pending : state_tbl -> identifier -> state_tbl
 (** Return all entries as a list. *)
 val tbl_to_list : state_tbl -> (identifier * loop_depth * var_state) list
 
+(** Get the list of pending variables. *)
+val get_pending : state_tbl -> identifier list
+
 (** Represents the number of times a given variable appears in an expression in different ways. *)
 type appearances
 

--- a/lib/LinearityCheck.mli
+++ b/lib/LinearityCheck.mli
@@ -46,6 +46,9 @@ val remove_entries : state_tbl -> identifier list -> state_tbl
 (** When a variable defined outside a loop is consumed inside a loop, it is marked as pending. *)
 val mark_pending : state_tbl -> identifier -> state_tbl
 
+(** When a pending variable is assigned to, it is removed from the pending list. *)
+val remove_pending : state_tbl -> identifier -> state_tbl
+
 (** Return all entries as a list. *)
 val tbl_to_list : state_tbl -> (identifier * loop_depth * var_state) list
 

--- a/lib/LinearityCheck.mli
+++ b/lib/LinearityCheck.mli
@@ -43,8 +43,8 @@ val remove_entry : state_tbl -> identifier -> state_tbl
 (** Remove a set of variables from the table. If any of them are not consumed, throws an error. *)
 val remove_entries : state_tbl -> identifier list -> state_tbl
 
-(** When a variable defined outside a loop is consumed inside a loop, it is marked as owed. *)
-val mark_owed : state_tbl -> identifier -> state_tbl
+(** When a variable defined outside a loop is consumed inside a loop, it is marked as pending. *)
+val mark_pending : state_tbl -> identifier -> state_tbl
 
 (** Return all entries as a list. *)
 val tbl_to_list : state_tbl -> (identifier * loop_depth * var_state) list

--- a/lib/LinearityCheck.mli
+++ b/lib/LinearityCheck.mli
@@ -43,6 +43,9 @@ val remove_entry : state_tbl -> identifier -> state_tbl
 (** Remove a set of variables from the table. If any of them are not consumed, throws an error. *)
 val remove_entries : state_tbl -> identifier list -> state_tbl
 
+(** When a variable defined outside a loop is consumed inside a loop, it is marked as owed. *)
+val mark_owed : state_tbl -> identifier -> state_tbl
+
 (** Return all entries as a list. *)
 val tbl_to_list : state_tbl -> (identifier * loop_depth * var_state) list
 

--- a/test-programs/suites/006-linearity/007-outside-for-loop/README.md
+++ b/test-programs/suites/006-linearity/007-outside-for-loop/README.md
@@ -1,1 +1,1 @@
-Test a linear value create inside a for loop cannot be consumed inside that loop.
+Test a linear value create inside a for loop cannot be consumed inside that loop without putting it back in.

--- a/test-programs/suites/006-linearity/007-outside-for-loop/austral-stderr.txt
+++ b/test-programs/suites/006-linearity/007-outside-for-loop/austral-stderr.txt
@@ -5,8 +5,6 @@ Error:
   Location:
     [no span available]
   Description:
-    The variable `r` was defined outside a loop, but you're trying to consume it inside a loop.
-
-    This is not allowed because it could be consumed zero times or more than once.
+    The  variable `r` was consumed in the loop, without afterwards being reassigned.
   Code:
     [no span available]

--- a/test-programs/suites/006-linearity/015-consume-and-assign-in-loop/README.md
+++ b/test-programs/suites/006-linearity/015-consume-and-assign-in-loop/README.md
@@ -1,0 +1,1 @@
+Test we can consume a linear value in a loop as long as we put it back later.

--- a/test-programs/suites/006-linearity/015-consume-and-assign-in-loop/Test.aum
+++ b/test-programs/suites/006-linearity/015-consume-and-assign-in-loop/Test.aum
@@ -1,0 +1,13 @@
+module body Test is
+    record Foo: Linear is
+    end;
+
+    function main(): ExitCode is
+        let foo: Foo := Foo();
+        for i from 0 to 10 do
+            let {} := foo;
+            foo := Foo();
+        end for;
+        return ExitSuccess();
+    end;
+end module body.

--- a/test-programs/suites/006-linearity/015-consume-and-assign-in-loop/Test.aum
+++ b/test-programs/suites/006-linearity/015-consume-and-assign-in-loop/Test.aum
@@ -8,6 +8,7 @@ module body Test is
             let {} := foo;
             foo := Foo();
         end for;
+        let {} := foo;
         return ExitSuccess();
     end;
 end module body.


### PR DESCRIPTION
Fix: #460 