### PR TITLE
CLI Parameters to Filter Test Programs Run

### DIFF
--- a/test-programs/runner.py
+++ b/test-programs/runner.py
@@ -541,15 +541,18 @@ def _run_program_failure_test(test: Test):
 #
 
 
-def run_all_tests(suites: list):
+def run_all_tests(suites: list, suite_pattern: str = "", name_pattern: str = ""):
     """
     Run the given suites.
+    An empty pattern means match all.
     """
     for suite in suites:
-        print(suite.name)
-        for test in suite.tests:
-            print(f"\t{test.name.ljust(45)}", end="")
-            run_test(test)
+        if len(suite_pattern) == 0 or suite.name.find(suite_pattern) != -1:
+            print(suite.name)
+            for test in suite.tests:
+                if len(name_pattern) == 0 or test.name.find(name_pattern) != -1:
+                    print(f"\t{test.name.ljust(45)}", end="")
+                    run_test(test)
 
 
 #
@@ -557,4 +560,8 @@ def run_all_tests(suites: list):
 #
 
 if __name__ == "__main__":
-    run_all_tests(collect_suites())
+    import sys
+
+    suite_pattern = sys.argv[1] if len(sys.argv) > 1 else ""
+    name_pattern = sys.argv[2] if len(sys.argv) > 2 else ""
+    run_all_tests(collect_suites(), suite_pattern, name_pattern)

--- a/test-programs/runner.py
+++ b/test-programs/runner.py
@@ -544,6 +544,9 @@ def _run_program_failure_test(test: Test):
 def run_all_tests(suites: list, suite_pattern: str = "", name_pattern: str = ""):
     """
     Run the given suites.
+
+    If suite_pattern is given, only tests in suites containing the given string are considered.
+    If name_pattern is given, only tests that have names containing the given string are run.
     An empty pattern means match all.
     """
     for suite in suites:


### PR DESCRIPTION
Tiny PR to let `test-programs/runner.py` filter tests by name.

New command line syntax is `test-programs/runner.py [SUITE] [TEST]` (both `SUITE` and `TEST` are optional).
Test suites that don't *contain* the string `SUITE` are skipped.
Of the suites run only tests containing the string `TEST` are run.

**Examples**:

```sh
$  python3 test-programs/runner.py 011 244
011-bugs
        github-244                                   PASS
```


```sh
$ python3 test-programs/runner.py 001
001-trivial
        001-null-program                             PASS
        002-embed                                    PASS
        003-sizeof                                   PASS
        004-for-loop                                 PASS
        005-hello-world                              PASS
        006-printable                                PASS
        007-root-cap                                 PASS
        008-abort                                    PASS
        009-docstrings                               PASS
        010-cli                                      PASS
        011-integer-conversions                      PASS
        012-else-if                                  PASS
        012-simple-assignment                        PASS
        014-named-records                            PASS
```