### PR TITLE
Reborrow expr

### DIFF
--- a/lib/AbstractionPass.ml
+++ b/lib/AbstractionPass.ml
@@ -93,6 +93,8 @@ and abs_expr im expr =
      SizeOf (qualify_typespec im ty)
   | CBorrowExpr (_, mode, var) ->
      BorrowExpr (mode, qualify_identifier im var)
+  | CReborrow (_, name) ->
+     Reborrow (qualify_identifier im name)
 
 and abs_when im (ConcreteWhen (name, bindings, body)) =
   AbstractWhen (name,

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -71,6 +71,7 @@ and aexpr =
   | Typecast of aexpr * qtypespec
   | SizeOf of qtypespec
   | BorrowExpr of borrowing_mode * qident
+  | Reborrow of qident
 
 and abstract_when =
   | AbstractWhen of identifier * qbinding list * astmt

--- a/lib/CodeGen.ml
+++ b/lib/CodeGen.ml
@@ -262,6 +262,8 @@ let rec gen_exp (mn: module_name) (e: mexpr): c_expr =
      CSizeOf (gen_type ty)
   | MBorrowExpr (_, name, _, _) ->
      CAddressOf (CVar (gen_ident name))
+  | MReborrow (name, _, _) ->
+     CVar (gen_ident name)
 
 and gen_path (mn: module_name) (expr: c_expr) (elems: mtyped_path_elem list): c_expr =
   match elems with

--- a/lib/Cst.ml
+++ b/lib/Cst.ml
@@ -90,6 +90,7 @@ and cexpr =
   | CTypecast of span * cexpr * typespec
   | CSizeOf of span * typespec
   | CBorrowExpr of span * borrowing_mode * identifier
+  | CReborrow of span * identifier
 
 and cstmt =
   | CSkip of span

--- a/lib/Error.ml
+++ b/lib/Error.ml
@@ -168,7 +168,7 @@ let internal_err (message: string) =
         module_name = None;
         kind = InternalError;
         text = [
-            Text "Internal compiler error:";
+            Text "Internal compiler error: ";
             Text message;
             Break;
             Text "This is a bug in the compiler, please open an issue here: ";

--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -121,6 +121,7 @@ rule token = parse
   | "&!" { BORROW_WRITE }
   | "&(" { REF_TRANSFORM }
   | "&" { BORROW_READ }
+  | "reborrow" { REBORROW }
   (* Keywords *)
   | "module" { MODULE }
   | "is" { IS }

--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -53,7 +53,7 @@ let advance_line lexbuf =
     pos_lnum = pos.pos_lnum + 1
   } in
   lexbuf.lex_curr_p <- pos'
-  
+
 let string_acc: Buffer.t = Buffer.create 64
 
 let triple_string_acc: Buffer.t = Buffer.create 64

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -328,6 +328,11 @@ let rec count (name: identifier) (expr: texpr): appearances =
            write_once)
      else
        zero_appearances
+  | TReborrow (name', _, _) ->
+     if equal_identifier name name' then
+       reborrow_once
+     else
+       zero_appearances
 
 and count_path_elem (name: identifier) (elem: typed_path_elem): appearances =
   match elem with

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -398,8 +398,12 @@ let partition (n: int): partitions =
 
 let tables_are_consistent (stmt_name: string) (a: state_tbl) (b: state_tbl): unit =
   (* Tables should have the same set of variable names. *)
-  let names_a: identifier list = List.map (fun (name, _, _, _) -> name) (tbl_to_list a)
-  and names_b: identifier list = List.map (fun (name, _, _, _) -> name) (tbl_to_list b)
+  let state_table_names (tbl: state_tbl): identifier list =
+    let l: identifier list = List.map (fun (name, _, _, _) -> name) (tbl_to_list tbl) in
+    List.sort (fun a b -> String.compare (ident_string a) (ident_string b)) l
+  in
+  let names_a: identifier list = state_table_names a
+  and names_b: identifier list = state_table_names b
   in
   if List.equal equal_identifier names_a names_b then
     (* Make a list of triples with the variable name, its state in A, and its

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -196,6 +196,14 @@ let path_once: appearances = {
     reborrow = 0;
   }
 
+let reborrow_once: appearances = {
+    consumed = 0;
+    read = 0;
+    write = 0;
+    path = 0;
+    reborrow = 1;
+  }
+
 let merge (a: appearances) (b: appearances): appearances =
   {
     consumed = a.consumed + b.consumed;

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -153,6 +153,7 @@ type appearances = {
     read: int;
     write: int;
     path: int;
+    reborrow: int;
   }
 
 let zero_appearances: appearances = {

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -161,6 +161,7 @@ let zero_appearances: appearances = {
     read = 0;
     write = 0;
     path = 0;
+    reborrow = 0;
   }
 
 let consumed_once: appearances = {
@@ -168,6 +169,7 @@ let consumed_once: appearances = {
     read = 0;
     write = 0;
     path = 0;
+    reborrow = 0;
   }
 
 let read_once: appearances = {
@@ -175,6 +177,7 @@ let read_once: appearances = {
     read = 1;
     write = 0;
     path = 0;
+    reborrow = 0;
   }
 
 let write_once: appearances = {
@@ -182,6 +185,7 @@ let write_once: appearances = {
     read = 0;
     write = 1;
     path = 0;
+    reborrow = 0;
   }
 
 let path_once: appearances = {
@@ -189,6 +193,7 @@ let path_once: appearances = {
     read = 0;
     write = 0;
     path = 1;
+    reborrow = 0;
   }
 
 let merge (a: appearances) (b: appearances): appearances =

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -210,6 +210,7 @@ let merge (a: appearances) (b: appearances): appearances =
     read = a.read + b.read;
     write = a.write + b.write;
     path = a.path + b.path;
+    reborrow = a.reborrow + b.reborrow;
   }
 
 let merge_list (l: appearances list): appearances =

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -685,7 +685,7 @@ let rec check_stmt (tbl: state_tbl) (depth: loop_depth) (stmt: tstmt): state_tbl
        pending_error new_pending
      else
        tbl
-  | TBorrow { original; mode; body; _ } ->
+  | TBorrow { original; mode; body; rename; ref_type; _ } ->
      (* Ensure the original variable is unconsumed to be borrowed. *)
      if is_unconsumed tbl original then
        let tbl: state_tbl =
@@ -694,6 +694,14 @@ let rec check_stmt (tbl: state_tbl) (depth: loop_depth) (stmt: tstmt): state_tbl
             update_tbl tbl original BorrowedRead
          | WriteBorrow ->
             update_tbl tbl original BorrowedWrite
+       in
+       (* If it's a mutable borrow, add the reference variable. *)
+       let tbl: state_tbl =
+         match mode with
+         | WriteBorrow ->
+           add_entry tbl rename ref_type depth
+         | ReadBorrow ->
+            tbl
        in
        (* Traverse the body. *)
        let tbl: state_tbl = check_stmt tbl depth body in

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -525,7 +525,7 @@ and error_consumed_and_something_else (name: identifier) =
    austral_raise LinearityError [
       Text "The variable ";
       Code (ident_string name);
-      Code " is consumed in the same expression where it is used in some other way.";
+      Text " is consumed in the same expression where it is used in some other way.";
       Break;
       Text "A linear variable cannot appear multiple times in the expression that consumes it.";
    ]

--- a/lib/LinearityCheck.ml
+++ b/lib/LinearityCheck.ml
@@ -460,11 +460,11 @@ let rec check_var_in_expr (tbl: state_tbl) (depth: loop_depth) (name: identifier
   match tup with
   (*       State        Consumed      WBorrow      Reborrow     RBorrow      Path    *)
   (* ---------------|-------------|-------------|------------|-----------|---------- *)
-  | (     Unconsumed,         Zero,         Zero,           _,          _,           _) -> (* Not yet consumed, and at most used through immutable borrows or path reads. *)
+  | (     Unconsumed,         Zero,         Zero,        Zero,          _,           _) -> (* Not yet consumed, and at most used through immutable borrows or path reads. *)
      tbl
-  | (     Unconsumed,         Zero,          One,           _,       Zero,        Zero) -> (* Not yet consumed, borrowed mutably once, and nothing else. *)
+  | (     Unconsumed,         Zero,          One,        Zero,       Zero,        Zero) -> (* Not yet consumed, borrowed mutably once, and nothing else. *)
      tbl
-  | (     Unconsumed,         Zero,          One,           _,          _,           _) -> (* Not yet consumed, borrowed mutably, then either borrowed immutably or accessed through a path. *)
+  | (     Unconsumed,         Zero,          One,           _,          _,           _) -> (* Not yet consumed, borrowed mutably, then either reborrowed, borrowed immutably or accessed through a path. *)
      error_borrowed_mutably_and_used name
   | (     Unconsumed,         Zero,  MoreThanOne,           _,          _,           _) -> (* Not yet consumed, borrowed mutably more than once. *)
      error_borrowed_mutably_more_than_once name

--- a/lib/Monomorphize.ml
+++ b/lib/Monomorphize.ml
@@ -288,6 +288,9 @@ let rec monomorphize_expr (env: env) (expr: texpr): (mexpr * env) =
   | TBorrowExpr (mode, name, region, ty) ->
      let (ty, env) = strip_and_mono env ty in
      (MBorrowExpr (mode, name, region, ty), env)
+  | TReborrow (name, ty, region) ->
+     let (ty, env) = strip_and_mono env ty in
+     (MReborrow (name, ty, region), env)
 
 and monomorphize_expr_list (env: env) (exprs: texpr list): (mexpr list * env) =
   match exprs with

--- a/lib/Mtast.ml
+++ b/lib/Mtast.ml
@@ -197,3 +197,5 @@ let rec get_type (e: mexpr): mono_ty =
          MonoReadRef (ty, MonoRegionTy region)
       | WriteBorrow ->
          MonoWriteRef (ty, MonoRegionTy region))
+  | MReborrow (_, ty, region) ->
+     MonoWriteRef (ty, MonoRegionTy region)

--- a/lib/Mtast.ml
+++ b/lib/Mtast.ml
@@ -98,6 +98,7 @@ and mexpr =
   | MTypecast of mexpr * mono_ty
   | MSizeOf of mono_ty
   | MBorrowExpr of borrowing_mode * identifier * region * mono_ty
+  | MReborrow of identifier * mono_ty * region
 
 and mtyped_when =
   MTypedWhen of identifier * mono_binding list * mstmt

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -41,6 +41,7 @@ open Span
 /* Borrowing */
 %token BORROW_WRITE
 %token BORROW_READ
+%token REBORROW
 %token REF_TRANSFORM
 /* Keywords */
 %token MODULE

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -398,6 +398,7 @@ atomic_expression:
   | SIZEOF LPAREN typespec RPAREN { CSizeOf (from_loc $loc, $3) }
   | BORROW_READ identifier { CBorrowExpr (from_loc $loc, ReadBorrow, $2) }
   | BORROW_WRITE identifier { CBorrowExpr (from_loc $loc, WriteBorrow, $2) }
+  | REBORROW LPAREN identifier RPAREN { CReborrow (from_loc $loc, $3) }
   | DEREF atomic_expression { CDeref (from_loc $loc, $2) }
   ;
 

--- a/lib/Tast.ml
+++ b/lib/Tast.ml
@@ -96,6 +96,8 @@ and texpr =
   | TDeref of texpr
   | TSizeOf of ty
   | TBorrowExpr of borrowing_mode * identifier * region * ty
+  | TReborrow of identifier * ty * region
+  (** `ty` is the type pointed to by the reference *)
 [@@deriving show]
 
 and typed_when =

--- a/lib/TastUtil.ml
+++ b/lib/TastUtil.ml
@@ -118,6 +118,8 @@ let rec get_type = function
          ReadRef (ty, RegionTy region)
       | WriteBorrow ->
          WriteRef (ty, RegionTy region))
+  | TReborrow (_, ty, region) ->
+     WriteRef (ty, RegionTy region)
 
 and path_elem_type = function
   | TSlotAccessor (_, t) ->

--- a/lib/TypeCheckExpr.ml
+++ b/lib/TypeCheckExpr.ml
@@ -974,11 +974,8 @@ and augment_reborrow (ctx: expr_ctx) (name: qident): texpr =
   in
   (* Create a fresh region. *)
   let reg: region = fresh_region () in
-  (* Construct the type of the new reference: same pointed-to type but change the
-     region. *)
-  let ty: ty = WriteRef (pointed_to, RegionTy reg) in
   (* Construct the expression. *)
-  TReborrow (original_name name, ty, reg)
+  TReborrow (original_name name, pointed_to, reg)
 
 and augment_arglist (ctx: expr_ctx) (args: abstract_arglist): typed_arglist =
   match args with

--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -30,6 +30,17 @@ let borrow_constant () =
     Text "Constants cannot be borrowed."
   ]
 
+let reborrow_constant () =
+  austral_raise TypeError [
+    Text "Constants cannot be borrowed."
+  ]
+
+let reborrow_wrong_type (ty: ty) =
+  austral_raise TypeError [
+      Text "Reborrow expressions take a variable of mutable reference type, but the expression has type ";
+      Code (type_string ty)
+  ]
+
 let borrow_non_linear ty =
   austral_raise TypeError [
     Text "Cannot borrow ";

--- a/lib/TypeReplace.ml
+++ b/lib/TypeReplace.ml
@@ -109,6 +109,9 @@ let rec replace_tyvars_expr (bindings: type_bindings) (expr: texpr): texpr =
   | TBorrowExpr (mode, name, region, ty) ->
      let ty = replace_variables bindings ty in
      TBorrowExpr (mode, name, region, ty)
+  | TReborrow (name, ty, region) ->
+     let ty = replace_variables bindings ty in
+     TReborrow (name, ty, region)
 
 and replace_tyvars_path (bindings: type_bindings) (elem: typed_path_elem): typed_path_elem =
   match elem with

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -547,6 +547,8 @@ and is_constant = function
      true
   | TBorrowExpr _ ->
      false
+  | TReborrow _ ->
+     false
 
 and is_path_elem_constant = function
   | TSlotAccessor _ ->

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -250,7 +250,7 @@ module body Standard.Buffer is
     generic [T: Free, R: Region]
     function fill(buf: &![Buffer[T], R], element: T): Unit is
         for i from 0 to buf->size - 1 do
-            storeNth(buf, i, element);
+            storeNth(reborrow(buf), i, element);
         end for;
         -- invariants(buf : &[Buffer[T], R]);
         return nil;
@@ -294,7 +294,7 @@ module body Standard.Buffer is
         -- If insertion would increase make `size` match `capacity`, resize
         -- the array.
         if (buf->size + 1) = buf->size then
-            bump(buf);
+            bump(reborrow(buf));
         end if;
         -- If the array is non-empty, we have to move everything to the right of
         -- the position one step to the right.
@@ -373,7 +373,7 @@ module body Standard.Buffer is
         if buf->size > 0 then
             for i from 0 to buf->size / 2 do
                 let j: Index := (buf->size - i) - 1;
-                swapIndex(buf, i, j);
+                swapIndex(reborrow(buf), i, j);
             end for;
         end if;
         -- invariants(buf : &[Buffer[T], R]);
@@ -387,7 +387,7 @@ module body Standard.Buffer is
     generic [T: Type, R: Region]
     function inPlaceMap(buf: &![Buffer[T], R], fn: Fn[T, T]): Unit is
         for i from 0 to buf->size - 1 do
-            swapTransform(buf, i, fn);
+            swapTransform(reborrow(buf), i, fn);
         end for;
         return nil;
     end;

--- a/test-programs/suites/007-borrowing/012-cant-reborrow-twice/README.md
+++ b/test-programs/suites/007-borrowing/012-cant-reborrow-twice/README.md
@@ -1,0 +1,1 @@
+Test we can't reborrow a mutable reference twice in an expression.

--- a/test-programs/suites/007-borrowing/012-cant-reborrow-twice/Test.aum
+++ b/test-programs/suites/007-borrowing/012-cant-reborrow-twice/Test.aum
@@ -1,0 +1,18 @@
+module body Test is
+    record Foo: Linear is
+    end;
+    
+    generic [R: Region, S: Region]
+    function bar(a: &![Foo, R], b: &![Foo, S]): Unit is
+        return nil;
+    end;
+
+    function main(): ExitCode is
+        let foo: Foo := Foo();
+        borrow! foo as fooref in R do
+            bar(reborrow(fooref), reborrow(fooref));
+        end;
+        let {} := foo;
+        return ExitSuccess();
+    end;
+end module body.

--- a/test-programs/suites/007-borrowing/012-cant-reborrow-twice/austral-stderr.txt
+++ b/test-programs/suites/007-borrowing/012-cant-reborrow-twice/austral-stderr.txt
@@ -1,0 +1,10 @@
+Error:
+  Title: Linearity Error
+  Module:
+    Test
+  Location:
+    [no span available]
+  Description:
+    The variable `fooref` is reborrowed multiple times in the same expression.
+  Code:
+    [no span available]

--- a/test-programs/suites/007-borrowing/013-reborrow-expr/README.md
+++ b/test-programs/suites/007-borrowing/013-reborrow-expr/README.md
@@ -1,0 +1,1 @@
+Test that reborrowing works as expected.

--- a/test-programs/suites/007-borrowing/013-reborrow-expr/Test.aum
+++ b/test-programs/suites/007-borrowing/013-reborrow-expr/Test.aum
@@ -1,0 +1,23 @@
+module body Test is
+    record Foo: Linear is
+        value: Int32;
+    end;
+    
+    generic [R: Region]
+    function show(a: &![Foo, R]): Unit is
+        print("value = ");
+        printLn(a->value);
+        return nil;
+    end;
+
+    function main(): ExitCode is
+        let foo: Foo := Foo(value => 10);
+        borrow! foo as fooref in R do
+            show(reborrow(fooref));
+            show(reborrow(fooref));
+            show(reborrow(fooref));
+        end;
+        let { value: Int32 } := foo;
+        return ExitSuccess();
+    end;
+end module body.

--- a/test-programs/suites/007-borrowing/013-reborrow-expr/program-stdout.txt
+++ b/test-programs/suites/007-borrowing/013-reborrow-expr/program-stdout.txt
@@ -1,0 +1,3 @@
+value = 10
+value = 10
+value = 10


### PR DESCRIPTION
This PR is built on top of #451 

This implements reborrowing expressions, which take a linear mutable reference, and, without consuming it, transform it into another linear mutable reference to a different region.