### PR TITLE
Replace explicit calls to type_string with a Type constructor for err_text

### DIFF
--- a/lib/Entrypoint.ml
+++ b/lib/Entrypoint.ml
@@ -54,7 +54,7 @@ module Errors = struct
       Text "The type of the entrypoint argument must be ";
       Code "RootCapability";
       Text " but it is ";
-      Code (type_string ty)
+      Type ty
     ]
 
   let wrong_return_type ty =
@@ -62,7 +62,7 @@ module Errors = struct
       Text "The type of the entrypoint function must be ";
       Code "ExitCode";
       Text " but it is ";
-      Code (type_string ty)
+      Type ty
     ]
 end
 

--- a/lib/ErrorText.ml
+++ b/lib/ErrorText.ml
@@ -29,14 +29,15 @@ and text_elem_to_plain (elem: text_elem): string =
      "\n\n"
  
 let rec error_text_to_html (txt: err_text): string =
-    String.concat "" (List.map (fun (elem: text_elem) ->
-                match elem with
-                | Text s ->
-                    s
-                | Code c ->
-                    "<code>" ^ c ^ "</code>"
-                | Type ty ->
-                    "<code>" ^ (type_string ty) ^ "</code>"
-                | Break ->
-                    "<br><br>"
-                ) txt)
+    String.concat "" (List.map text_elem_to_html txt)
+
+and text_elem_to_html (elem: text_elem): string =
+  match elem with
+  | Text s ->
+      s
+  | Code c ->
+      "<code>" ^ c ^ "</code>"
+  | Type ty ->
+      "<code>" ^ (type_string ty) ^ "</code>"
+  | Break ->
+      "<br><br>"

--- a/lib/ErrorText.ml
+++ b/lib/ErrorText.ml
@@ -4,12 +4,14 @@
 
    SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 *)
+open Type
 
 type err_text = text_elem list
 
 and text_elem =
   | Text of string
   | Code of string
+  | Type of ty
   | Break
 
 let rec error_text_to_plain (txt: err_text): string =
@@ -21,6 +23,8 @@ and text_elem_to_plain (elem: text_elem): string =
      s
   | Code c ->
      "`" ^ c ^ "`"
+  | Type ty ->
+     "`" ^ (type_string ty) ^ "`"
   | Break ->
      "\n\n"
  
@@ -31,6 +35,8 @@ let rec error_text_to_html (txt: err_text): string =
                     s
                 | Code c ->
                     "<code>" ^ c ^ "</code>"
+                | Type ty ->
+                    "<code>" ^ (type_string ty) ^ "</code>"
                 | Break ->
                     "<br><br>"
                 ) txt)

--- a/lib/ErrorText.mli
+++ b/lib/ErrorText.mli
@@ -7,6 +7,7 @@
 (** This module provides a representation-independent way of writing the text in
     error messages. Rather than concatenating strings, we use a more structured
     representation, which can then be rendered to both plain text and HTML. *)
+open Type
 
 (** The contents of an error message. *)
 type err_text = text_elem list
@@ -17,6 +18,8 @@ and text_elem =
   (** Human-readable prose. *)
   | Code of string
   (** Austral text, like the name of an identifier or a type. *)
+  | Type of ty
+  (** An Austral type. *)
   | Break
   (** A paragraph break. *)
 

--- a/lib/ExportInstantiation.ml
+++ b/lib/ExportInstantiation.ml
@@ -17,7 +17,7 @@ module Errors = struct
   let disallowed_type ty =
     austral_raise TypeError [
       Text "The type ";
-      Code (type_string ty);
+      Type ty;
       Text " is not allowed in the signature of an exported function."
     ]
 end

--- a/lib/TypeBindings.ml
+++ b/lib/TypeBindings.ml
@@ -19,9 +19,9 @@ module Errors = struct
       Text "The type parameter ";
       Code (typaram_name param |> ident_string);
       Text " cannot be bound to both ";
-      Code (type_string was);
+      Type was;
       Text " and ";
-      Code (type_string redef)
+      Type redef;
     ]
 
   let typaram_wrong_universe ~param ~ty ~expected ~actual =
@@ -31,7 +31,7 @@ module Errors = struct
       Text " must be ";
       Code (universe_string expected);
       Text " but ";
-      Code (type_string ty);
+      Type ty;
       Text " is ";
       Code (universe_string actual)
     ]

--- a/lib/TypeCheckExpr.mli
+++ b/lib/TypeCheckExpr.mli
@@ -25,10 +25,10 @@ val make_ctx : module_name -> env -> region_map -> typarams -> lexenv -> expr_ct
     expressions. *)
 val augment_expr : expr_ctx -> ty option -> aexpr -> texpr
 
-val augment_slot_accessor_elem : expr_ctx -> identifier -> qident -> ty list -> typed_path_elem
+val augment_slot_accessor_elem : expr_ctx -> identifier -> qident -> ty list -> ty -> typed_path_elem
 
 val augment_pointer_slot_accessor_elem : expr_ctx -> identifier -> ty -> typed_path_elem
 
-val augment_reference_slot_accessor_elem : expr_ctx -> identifier -> qident -> ty list -> typed_path_elem
+val augment_reference_slot_accessor_elem : expr_ctx -> identifier -> qident -> ty list -> ty -> typed_path_elem
 
 val cast_arguments : type_bindings -> value_parameter list -> texpr list -> texpr list

--- a/lib/TypeClasses.ml
+++ b/lib/TypeClasses.ml
@@ -42,7 +42,7 @@ module Errors = struct
   let not_a_tyvar ty =
     austral_raise DeclarationError [
       Text "The type ";
-      Code (type_string ty);
+      Type ty;
       Text " is not a type parameter, but generic instances must use either all type parameters or none of them in the argument.";
       Break;
       Text "Consider adding another generic parameter with universe ";
@@ -71,7 +71,7 @@ module Errors = struct
   let wrong_universe ~ty ~expected ~actual =
     austral_raise TypeError [
       Text "Cannot define an instance with argument ";
-      Code (type_string ty);
+      Type ty;
       Text " because it should belong to the ";
       Code (universe_string expected);
       Text " universe, but it is actually in the ";

--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -290,7 +290,7 @@ let path_not_public ~type_name ~slot_name =
 let path_not_record ty =
   austral_raise TypeError [
     Text "Cannot take a path of the type ";
-    Code ty;
+    Type ty;
     Text " because it is not a record."
   ]
 

--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -6,23 +6,23 @@ open Type
 let arithmetic_incompatible_types ~lhs ~rhs =
   austral_raise TypeError [
     Text "Both operands to an arithmetic expression must be compatible types. The LHS has type ";
-    Code (type_string lhs);
+    Type lhs;
     Text " but the RHS has type ";
-    Code (type_string rhs);
+    Type rhs;
     Text "."
   ]
 
 let arithmetic_not_numeric ty =
   austral_raise TypeError [
     Text "Both operands of an arithmetic operator must be numeric types, but ";
-    Code (type_string ty);
+    Type ty;
     Text " is not."
   ]
 
 let array_indexing_disallowed ty =
   austral_raise TypeError [
     Text "The array indexing operator is not allowed for the type ";
-    Code (type_string ty)
+    Type ty
   ]
 
 let borrow_constant () =
@@ -38,20 +38,20 @@ let reborrow_constant () =
 let reborrow_wrong_type (ty: ty) =
   austral_raise TypeError [
       Text "Reborrow expressions take a variable of mutable reference type, but the expression has type ";
-      Code (type_string ty)
+      Type ty
   ]
 
 let borrow_non_linear ty =
   austral_raise TypeError [
     Text "Cannot borrow ";
-    Code (type_string ty);
+    Type ty;
     Text " because it is not a linear type."
   ]
 
 let call_non_callable ty =
   austral_raise TypeError [
     Text "The type ";
-    Code (type_string ty);
+    Type ty;
     Text " is neither a function, method or function pointer, and cannot be called."
   ]
 
@@ -82,7 +82,7 @@ let case_non_public () =
 let case_non_union ty =
   austral_raise TypeError [
     Text "The case expression has type ";
-    Code (type_string ty);
+    Type ty;
     Text " which is not a union type."
   ]
 
@@ -108,9 +108,9 @@ let cast_different_references ~different_types ~different_regions =
 let cast_invalid ~target ~source =
   austral_raise TypeError [
     Text "Cannot cast to ";
-    Code (type_string target);
+    Type target;
     Text " from ";
-    Code (type_string source)
+    Type source
   ]
 
 let cast_write_ref_to_non_ref () =
@@ -125,7 +125,7 @@ let condition_not_boolean ~kind ~form ~ty =
     Text "-";
     Text form;
     Text "s should be a boolean type, but is ";
-    Code (type_string ty)
+    Type ty
   ]
 
 let constructor_not_named declaration =
@@ -145,34 +145,34 @@ let constructor_wrong_args declaration =
 let dereference_non_reference ty =
   austral_raise TypeError [
     Text "Only references can be dereferenced, but ";
-    Code (type_string ty);
+    Type ty;
     Text " is not."
   ]
 
 let dereference_non_free ty =
   austral_raise LinearityError [
     Text "Cannot dereference non-free type ";
-    Code (type_string ty)
+    Type ty
   ]
 
 let destructure_non_record ty =
   austral_raise TypeError [
     Text "The type ";
-    Code (type_string ty);
+    Type ty;
     Text " cannot be destructured because it is not a record."
   ]
 
 let destructure_not_public ty =
   austral_raise TypeError [
     Text "The type ";
-    Code (type_string ty);
+    Type ty;
     Text " is not a public record and so cannot be destructured."
   ]
 
 let destructure_wrong_slots ty =
   austral_raise TypeError [
     Text "The set of slots mentioned differs from the set of slots in ";
-    Code (type_string ty);
+    Type ty;
   ]
 
 let discard_linear universe =
@@ -192,7 +192,7 @@ let for_bounds_non_integral ~bound ~ty =
     Text "The type of the ";
     Text bound;
     Text " value in the loop range is ";
-    Code (type_string ty);
+    Type ty;
     Text " which is not an integer type."
   ]
 
@@ -221,9 +221,9 @@ let if_inequal ~lhs ~rhs =
     Text "The branches of the ";
     Code "if";
     Text "-expression have different types: ";
-    Code (type_string lhs);
+    Type lhs;
     Text " and ";
-    Code (type_string rhs)
+    Type rhs
   ]
 
 let logical_operands_not_boolean ~operator ~types = match types with
@@ -232,16 +232,16 @@ let logical_operands_not_boolean ~operator ~types = match types with
       Text "The operand of a ";
       Text operator;
       Text " operator must be a boolean expression, but it has the type ";
-      Code (type_string ty)
+      Type ty
     ]
 | [first; second] ->
     austral_raise TypeError [
       Text "Both operands of a ";
       Text operator;
       Text " operator must be boolean expressions, but they have types ";
-      Code (type_string first);
+      Type first;
       Text " and ";
-      Code (type_string second)
+      Type second
     ]
   | _ ->
     austral_raise TypeError [
@@ -266,13 +266,13 @@ let no_suitable_instance ~typeclass ~ty =
     Text "The typeclass ";
     Code (ident_string typeclass);
     Text " has no instance which matches for ";
-    Code (type_string ty)
+    Type ty
   ]
 
 let path_not_free ty =
   austral_raise TypeError [
     Text "The path ends with the type ";
-    Code (type_string ty);
+    Type ty;
     Text " which is not in the ";
     Code "Free";
     Text " universe."
@@ -299,9 +299,9 @@ let slot_wrong_type ~name ~expected ~actual =
     Text "The slot ";
     Code (ident_string name);
     Text " should have type ";
-    Code (type_string expected);
+    Type expected;
     Text " but is declared to have type ";
-    Code (type_string actual)
+    Type actual
   ]
 
 let unconstrained_generic_function name =
@@ -344,12 +344,12 @@ let cannot_assign_to_parameter _ =
 let ref_transform_needs_ref ty =
   austral_raise GenericError [
       Text "The head of a reference transform expression must be of a reference type, but I got ";
-      Code (type_string ty)
+      Type ty
     ]
 
 let ref_transform_not_record ty =
   austral_raise GenericError [
       Text "Tried to transform a reference to a record into a reference into a slot, but the type ";
-      Code (type_string ty);
+      Type ty;
       Text " is not a record"
     ]

--- a/lib/TypeMatch.ml
+++ b/lib/TypeMatch.ml
@@ -24,9 +24,9 @@ module Errors = struct
   let type_mismatch a b =
     austral_raise TypeError [
       Text "Expected a value of type ";
-      Code (type_string a);
+      Type a;
       Text ", but got a value of type ";
-      Code (type_string b);
+      Type b;
       Text "."
     ]
 
@@ -34,7 +34,7 @@ module Errors = struct
     let (TypeVariable (tv_name, _, _, _)) = tv in
     austral_raise TypeError [
         Text "Type constraint not satisfied: the type ";
-        Code (type_string ty);
+        Type ty;
         Text " does not implement the typeclass ";
         Code (ident_string (sident_name constraint_typeclass_name));
         Text ".";

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -339,7 +339,7 @@ and augment_case (ctx: stmt_ctx) (span: span) (expr: aexpr) (whens: abstract_whe
          | _ ->
             austral_raise TypeError [
                 Text "The type for the expression in a case statement must be a union or a reference to a union, but I got ";
-                Code (type_string ty)
+                Type ty
         ])
       in
       let case_ref: case_ref =


### PR DESCRIPTION
Centralizes type rendering in error reporting.

Related to: #468 