### PR TITLE
Fix Standard.Buffer:initialize fails with size=0 

### DIFF
--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -108,9 +108,9 @@ module body Standard.Buffer is
 
     generic [T: Free]
     function safeInitialize(size: Index, initialElement: T): Option[Buffer[T]] is
-		if size = 0 then
-		  return safeAllocateEmpty();
-		end if;
+        if size = 0 then
+            return safeAllocateEmpty();
+        end if;
         let capacity: Index := max(size, minimum_capacity);
         let addr: Address[T] := allocateBuffer(capacity);
         case nullCheck(addr) of

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -108,6 +108,9 @@ module body Standard.Buffer is
 
     generic [T: Free]
     function safeInitialize(size: Index, initialElement: T): Option[Buffer[T]] is
+		if size = 0 then
+		  return safeAllocateEmpty();
+		end if;
         let capacity: Index := max(size, minimum_capacity);
         let addr: Address[T] := allocateBuffer(capacity);
         case nullCheck(addr) of

--- a/standard/test/Buffer.aum
+++ b/standard/test/Buffer.aum
@@ -77,7 +77,7 @@ module body Standard.Test.Buffer is
         return nil;
     end;
     
-	function initializeEmptyTest(): Unit is
+    function initializeEmptyTest(): Unit is
         testHeading("initializeEmpty");
         let b: Buffer[Int32] := initialize(0, 10);
         assertLength(&b, 0);

--- a/standard/test/Buffer.aum
+++ b/standard/test/Buffer.aum
@@ -40,6 +40,7 @@ module body Standard.Test.Buffer is
         suiteHeading("Standard.Buffer");
         basicLifecycleTest();
         initializeTest();
+        initializeEmptyTest();
         storeTest();
         swapNthTest();
         swapIndexTest();
@@ -75,7 +76,16 @@ module body Standard.Test.Buffer is
         assertSuccess("destroyFree complete");
         return nil;
     end;
-
+    
+	function initializeEmptyTest(): Unit is
+        testHeading("initializeEmpty");
+        let b: Buffer[Int32] := initialize(0, 10);
+        assertLength(&b, 0);
+        destroyFree(b);
+        assertSuccess("destroyFree complete");
+        return nil;
+    end;
+    
     function storeTest(): Unit is
         testHeading("storeNth");
         let b: Buffer[Int32] := initialize(1, 10);


### PR DESCRIPTION
Fix #469 by adding a conditional guard to Buffer:initializeSafe for when 0 is passed to Buffer:initialize. A corresponding test is added in the Buffer module