### PR TITLE
Test consuming and assigning a variable in one branch of an if-else

### DIFF
--- a/test-programs/suites/006-linearity/018-consume-and-assign-in-if/README.md
+++ b/test-programs/suites/006-linearity/018-consume-and-assign-in-if/README.md
@@ -1,0 +1,1 @@
+Test we can consume a linear value in one branch of an if statement as long as we put it back later.

--- a/test-programs/suites/006-linearity/018-consume-and-assign-in-if/Test.aum
+++ b/test-programs/suites/006-linearity/018-consume-and-assign-in-if/Test.aum
@@ -1,0 +1,16 @@
+module body Test is
+    record Foo: Linear is
+    end;
+
+    function main(): ExitCode is
+        var foo: Foo := Foo();
+        if true then
+            let {} := foo;
+            foo := Foo();
+        else
+            skip;
+        end if;
+        let {} := foo;
+        return ExitSuccess();
+    end;
+end module body.


### PR DESCRIPTION
This is different to cases 003-005 because the variable is replaced after being consumed - which makes it legal to only reference the variable in a single branch.

Happy to add more combinations here if you want the test to be more comprehensive!