### PR TITLE
Better syntax for the borrow statement

### DIFF
--- a/examples/box/Box.aum
+++ b/examples/box/Box.aum
@@ -101,10 +101,10 @@ module body Example.Box is
         let b2: Either[Box[Int32], Int32] := Make('a');
         case b2 of
             when Left(left: Box[Int32]) do
-                borrow left as value2 in rho do
+                borrow value2: &[Box[Int32], rho] := &left do
                     let contents: Int32 := Read_Free(value2);
                     Put_Character(contents);
-                end;
+                end borrow;
                 Unbox(left);
             when Right(right: Int32) do
                 abort("Unexpected.");
@@ -126,11 +126,11 @@ module body Example.Box is
         let b4: Either[Box[Int32], Int32] := Make('a');
         case b4 of
             when Left(left: Box[Int32]) do
-                borrow left as boxref in rho do
+                borrow boxref: &[Box[Int32], rho] := &left do
                     let valueref: &[Int32, rho] := Get_Value_Ref(boxref);
                     let contents: Int32 := !(valueref);
                     Put_Character(contents);
-                end;
+                end borrow;
                 Unbox(left);
             when Right(right: Int32) do
                 abort("Unexpected.");

--- a/examples/box/Box.aum
+++ b/examples/box/Box.aum
@@ -114,9 +114,9 @@ module body Example.Box is
         case b3 of
             when Left(left: Box[Int32]) do
                 var left2: Box[Int32] := left;
-                borrow! left2 as value2 in rho do
+                borrow value2: &![Box[Int32], rho] := &!left2 do
                     Store_Free(value2, 'a');
-                end;
+                end borrow;
                 let contents: Int32 := Unbox(left2);
                 Put_Character(contents);
             when Right(right: Int32) do
@@ -140,9 +140,9 @@ module body Example.Box is
         case b5 of
             when Left(left: Box[Int32]) do
                 var left2: Box[Int32] := left;
-                borrow! left2 as boxmutref in rho do
+                borrow boxmutref: &![Box[Int32], rho] := &!left2 do
                     Swap_Mut(boxmutref, 'a');
-                end;
+                end borrow;
                 Put_Character(Unbox(left2));
             when Right(right: Int32) do
                 abort("Unexpected.");

--- a/examples/buffer/Buffer.aum
+++ b/examples/buffer/Buffer.aum
@@ -124,14 +124,14 @@ module body Example.Buffer is
     function main(): ExitCode is
         -- Create a buffer of e's.
         let buf: Buffer[Int32] := Initialize(3, 101);
-        borrow buf as bufref in rho do
+        borrow bufref: &[Buffer[Int32], rho] := &buf do
             let size: Index := Buffer_Size(bufref);
             if size = 3 then
                 Put_Character(97);
             end if;
             let first: Int32 := Nth_Free(bufref, 0);
             Put_Character(first);
-        end;
+        end borrow;
         Destroy_Buffer(buf);
         return ExitSuccess();
     end;

--- a/examples/ref-to-record/RTR.aum
+++ b/examples/ref-to-record/RTR.aum
@@ -11,10 +11,10 @@ module body Example.RTR is
 
     function main(): ExitCode is
         let r: R := R(X => 97);
-        borrow r as r2 in rho do
+        borrow r2: &[R, rho] := &r do
             let c: Int32 := r2->X;
             Put_Character(c);
-        end;
+        end borrow;
         let { X: Int32 } := r;
         Put_Character(X);
         return ExitSuccess();

--- a/lib/Lexer.mll
+++ b/lib/Lexer.mll
@@ -155,9 +155,6 @@ rule token = parse
   | "from" { FROM }
   | "to" { TO }
   | "borrow" { BORROW }
-  | "borrow!" { MUTABLE_BORROW }
-  | "borrow~" { REBORROW_STMT }
-  | "in" { IN }
   | "return" { RETURN }
   | "skip" { SKIP }
   | "Free" { UNIVERSE_FREE }

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -385,7 +385,8 @@ read_borrow_stmt:
   ;
 
 mutable_borrow_stmt:
-  | MUTABLE_BORROW o=identifier AS n=identifier IN r=identifier DO b=block END SEMI { CBorrow { span=from_loc $loc; original=o; rename=n; region=r; body=b; mode=Write } }
+  | BORROW name=identifier COLON BORROW_WRITE LBRACKET typespec COMMA reg=identifier RBRACKET ASSIGN BORROW_WRITE orig=identifier DO body=block END BORROW SEMI
+    { CBorrow { span=from_loc $loc; original=orig; rename=name; region=reg; body=body; mode=Write } }
   ;
 
 reborrow_stmt:

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -374,26 +374,20 @@ when_stmt:
   ;
 
 borrow_stmt:
-  | read_borrow_stmt { $1 }
-  | mutable_borrow_stmt { $1 }
-  | reborrow_stmt { $1 }
+  | BORROW name=identifier COLON borrow_stmt_read_or_write LBRACKET typespec COMMA reg=identifier RBRACKET ASSIGN mode=borrow_stmt_mode orig=identifier DO body=block END BORROW SEMI
+    { CBorrow { span=from_loc $loc; original=orig; rename=name; region=reg; body=body; mode=mode } }
   ;
 
-read_borrow_stmt:
-  | BORROW name=identifier COLON BORROW_READ LBRACKET typespec COMMA reg=identifier RBRACKET ASSIGN BORROW_READ orig=identifier DO body=block END BORROW SEMI
-    { CBorrow { span=from_loc $loc; original=orig; rename=name; region=reg; body=body; mode=Read } }
+borrow_stmt_read_or_write:
+  | BORROW_READ { () }
+  | BORROW_WRITE { () }
   ;
 
-mutable_borrow_stmt:
-  | BORROW name=identifier COLON BORROW_WRITE LBRACKET typespec COMMA reg=identifier RBRACKET ASSIGN BORROW_WRITE orig=identifier DO body=block END BORROW SEMI
-    { CBorrow { span=from_loc $loc; original=orig; rename=name; region=reg; body=body; mode=Write } }
+borrow_stmt_mode:
+  | BORROW_READ { Read }
+  | BORROW_WRITE { Write }
+  | REBORROW { Reborrow }
   ;
-
-reborrow_stmt:
-  | BORROW name=identifier COLON REBORROW LBRACKET typespec COMMA reg=identifier RBRACKET ASSIGN REBORROW orig=identifier DO body=block END BORROW SEMI
-    { CBorrow { span=from_loc $loc; original=orig; rename=name; region=reg; body=body; mode=Reborrow } }
-  ;
-
 
 block:
   | blocklist { CBlock (from_loc $loc, $1) }

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -390,8 +390,10 @@ mutable_borrow_stmt:
   ;
 
 reborrow_stmt:
-  | REBORROW_STMT o=identifier AS n=identifier IN r=identifier DO b=block END SEMI { CBorrow { span=from_loc $loc; original=o; rename=n; region=r; body=b; mode=Reborrow } }
+  | BORROW name=identifier COLON REBORROW LBRACKET typespec COMMA reg=identifier RBRACKET ASSIGN REBORROW orig=identifier DO body=block END BORROW SEMI
+    { CBorrow { span=from_loc $loc; original=orig; rename=name; region=reg; body=body; mode=Reborrow } }
   ;
+
 
 block:
   | blocklist { CBlock (from_loc $loc, $1) }

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -76,9 +76,6 @@ open Span
 %token FROM
 %token TO
 %token BORROW
-%token MUTABLE_BORROW
-%token REBORROW_STMT
-%token IN
 %token RETURN
 %token SKIP
 %token UNIVERSE_FREE

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -380,7 +380,8 @@ borrow_stmt:
   ;
 
 read_borrow_stmt:
-  | BORROW o=identifier AS n=identifier IN r=identifier DO b=block END SEMI { CBorrow { span=from_loc $loc; original=o; rename=n; region=r; body=b; mode=Read } }
+  | BORROW name=identifier COLON BORROW_READ LBRACKET typespec COMMA reg=identifier RBRACKET ASSIGN BORROW_READ orig=identifier DO body=block END BORROW SEMI
+    { CBorrow { span=from_loc $loc; original=orig; rename=name; region=reg; body=body; mode=Read } }
   ;
 
 mutable_borrow_stmt:

--- a/test-programs/suites/007-borrowing/001-explicit-read/Test.aum
+++ b/test-programs/suites/007-borrowing/001-explicit-read/Test.aum
@@ -13,13 +13,13 @@ module body Test is
         -- Create a linear record.
         let foo: Foo := Foo(bar => 'a');
         -- Borrow it.
-        borrow foo as fooref in rho do
+        borrow fooref: &[Foo, rho] := &foo do
             -- Extract a free value from the reference.
             let subref: &[Nat8, rho] := &(fooref->bar);
             let b: Nat8 := !subref;
             -- Print it.
             Put_Character(b);
-        end;
+        end borrow;
         -- Consume the record by destructuring.
         let { bar: Nat8 } := foo;
         return ExitSuccess();

--- a/test-programs/suites/007-borrowing/004-explicit-borrow-after-consume/Test.aum
+++ b/test-programs/suites/007-borrowing/004-explicit-borrow-after-consume/Test.aum
@@ -9,9 +9,9 @@ module body Test is
         -- Consume the record by destructuring.
         let { bar: Nat8 } := foo;
         -- Try to borrow it.
-        borrow foo as fooref in rho do
+        borrow fooref: &[Foo, rho] := &foo do
             skip;
-        end;
+        end borrow;
         return ExitSuccess();
     end;
 end module body.

--- a/test-programs/suites/007-borrowing/004-explicit-borrow-after-consume/austral-stderr.txt
+++ b/test-programs/suites/007-borrowing/004-explicit-borrow-after-consume/austral-stderr.txt
@@ -11,14 +11,14 @@
   "span": {
     "filename": "test-programs/suites/007-borrowing/004-explicit-borrow-after-consume/Test.aum",
     "startp": { "line": 12, "column": 8 },
-    "end": { "line": 14, "column": 12 }
+    "end": { "line": 14, "column": 19 }
   },
   "context": [
     [ 10, "        let { bar: Nat8 } := foo;" ],
     [ 11, "        -- Try to borrow it." ],
-    [ 12, "        borrow foo as fooref in rho do" ],
+    [ 12, "        borrow fooref: &[Foo, rho] := &foo do" ],
     [ 13, "            skip;" ],
-    [ 14, "        end;" ],
+    [ 14, "        end borrow;" ],
     [ 15, "        return ExitSuccess();" ],
     [ 16, "    end;" ]
   ]

--- a/test-programs/suites/007-borrowing/006-nested-explicit-borrow/Test.aum
+++ b/test-programs/suites/007-borrowing/006-nested-explicit-borrow/Test.aum
@@ -7,12 +7,12 @@ module body Test is
         -- Create a linear record.
         let foo: Foo := Foo(bar => 'a');
         -- Borrow it.
-        borrow foo as fooref in rho do
+        borrow fooref: &[Foo, rho] := &foo do
             -- Borrow it again.
-            borrow foo as fooref2 in rho2 do
+            borrow fooref2: &[Foo, R] := &foo do
                 printLn(fooref2->bar);
-            end;
-        end;
+            end borrow;
+        end borrow;
         -- Consume the record by destructuring.
         let { bar: Nat8 } := foo;
         return ExitSuccess();

--- a/test-programs/suites/007-borrowing/007-nested-explicit-anon-borrow/Test.aum
+++ b/test-programs/suites/007-borrowing/007-nested-explicit-anon-borrow/Test.aum
@@ -7,10 +7,10 @@ module body Test is
         -- Create a linear record.
         let foo: Foo := Foo(bar => 'a');
         -- Borrow it.
-        borrow foo as fooref in rho do
+        borrow fooref: &[Foo, R] := &foo do
             -- Borrow it again.
             &foo;
-        end;
+        end borrow;
         -- Consume the record by destructuring.
         let { bar: Nat8 } := foo;
         return ExitSuccess();

--- a/test-programs/suites/007-borrowing/009-dereference-linear/Test.aum
+++ b/test-programs/suites/007-borrowing/009-dereference-linear/Test.aum
@@ -3,9 +3,9 @@ module body Test is
 
     function main(): ExitCode is
         let foo: Foo := Foo();
-        borrow foo as ref in R do
+        borrow ref: &[Foo, R] := &foo do
             let {} := !ref;
-        end;
+        end borrow;
         let {} := foo;
         return ExitSuccess();
     end;

--- a/test-programs/suites/007-borrowing/009-dereference-linear/austral-stderr.txt
+++ b/test-programs/suites/007-borrowing/009-dereference-linear/austral-stderr.txt
@@ -12,9 +12,9 @@
   },
   "context": [
     [ 5, "        let foo: Foo := Foo();" ],
-    [ 6, "        borrow foo as ref in R do" ],
+    [ 6, "        borrow ref: &[Foo, R] := &foo do" ],
     [ 7, "            let {} := !ref;" ],
-    [ 8, "        end;" ],
+    [ 8, "        end borrow;" ],
     [ 9, "        let {} := foo;" ]
   ]
 }

--- a/test-programs/suites/007-borrowing/010-dereference-free/Test.aum
+++ b/test-programs/suites/007-borrowing/010-dereference-free/Test.aum
@@ -5,12 +5,12 @@ module body Test is
 
     function main(): ExitCode is
         let foo: Foo := Foo(inner => 5);
-        borrow foo as ref in R do
+        borrow ref: &[Foo, R] := &foo do
             let subref: &[Int64, R] := &(ref->inner);
             let value: Int64 := !subref;
             print("value = ");
             printLn(value);
-        end;
+        end borrow;
         let { inner: Int64 } := foo;
         return ExitSuccess();
     end;

--- a/test-programs/suites/007-borrowing/011-drop-mutable-ref/Test.aum
+++ b/test-programs/suites/007-borrowing/011-drop-mutable-ref/Test.aum
@@ -9,9 +9,9 @@ module body Test is
 
     function main(): ExitCode is
         var foo: Foo := Foo();
-        borrow! foo as fooref in R do
+        borrow fooref: &![Foo, R] := &!foo do
             skip;
-        end;
+        end borrow;
         bar(&!foo);
         let {} := foo;
         return ExitSuccess();

--- a/test-programs/suites/007-borrowing/012-cant-reborrow-twice/Test.aum
+++ b/test-programs/suites/007-borrowing/012-cant-reborrow-twice/Test.aum
@@ -9,9 +9,9 @@ module body Test is
 
     function main(): ExitCode is
         var foo: Foo := Foo();
-        borrow! foo as fooref in R do
+        borrow fooref: &![Foo, R] := &!foo do
             bar(&~fooref, &~fooref);
-        end;
+        end borrow;
         let {} := foo;
         return ExitSuccess();
     end;

--- a/test-programs/suites/007-borrowing/012-cant-reborrow-twice/austral-stderr.txt
+++ b/test-programs/suites/007-borrowing/012-cant-reborrow-twice/austral-stderr.txt
@@ -11,14 +11,14 @@
   "span": {
     "filename": "test-programs/suites/007-borrowing/012-cant-reborrow-twice/Test.aum",
     "startp": { "line": 12, "column": 8 },
-    "end": { "line": 14, "column": 12 }
+    "end": { "line": 14, "column": 19 }
   },
   "context": [
     [ 10, "    function main(): ExitCode is" ],
     [ 11, "        var foo: Foo := Foo();" ],
-    [ 12, "        borrow! foo as fooref in R do" ],
+    [ 12, "        borrow fooref: &![Foo, R] := &!foo do" ],
     [ 13, "            bar(&~fooref, &~fooref);" ],
-    [ 14, "        end;" ],
+    [ 14, "        end borrow;" ],
     [ 15, "        let {} := foo;" ],
     [ 16, "        return ExitSuccess();" ]
   ]

--- a/test-programs/suites/007-borrowing/013-reborrow-expr/Test.aum
+++ b/test-programs/suites/007-borrowing/013-reborrow-expr/Test.aum
@@ -12,11 +12,11 @@ module body Test is
 
     function main(): ExitCode is
         var foo: Foo := Foo(value => 10);
-        borrow! foo as fooref in R do
+        borrow fooref: &![Foo, R] := &!foo do
             show(&~fooref);
             show(&~fooref);
             show(&~fooref);
-        end;
+        end borrow;
         let { value: Int32 } := foo;
         return ExitSuccess();
     end;

--- a/test-programs/suites/007-borrowing/014-reborrow-stmt/Test.aum
+++ b/test-programs/suites/007-borrowing/014-reborrow-stmt/Test.aum
@@ -13,15 +13,15 @@ module body Test is
     function main(): ExitCode is
         var foo: Foo := Foo(value => 10);
         borrow fooref: &![Foo, R] := &!foo do
-            borrow~ fooref as fooref2a in R2 do
+            borrow fooref2a: &![Foo, R2] := &~fooref do
                 show(fooref2a);
-            end;
-            borrow~ fooref as fooref2b in R2 do
+            end borrow;
+            borrow fooref2b: &![Foo, R2] := &~fooref do
                 show(fooref2b);
-            end;
-            borrow~ fooref as fooref2c in R2 do
+            end borrow;
+            borrow fooref2c: &![Foo, R2] := &~fooref do
                 show(fooref2c);
-            end;
+            end borrow;
         end borrow;
         let { value: Int32 } := foo;
         return ExitSuccess();

--- a/test-programs/suites/007-borrowing/014-reborrow-stmt/Test.aum
+++ b/test-programs/suites/007-borrowing/014-reborrow-stmt/Test.aum
@@ -12,7 +12,7 @@ module body Test is
 
     function main(): ExitCode is
         var foo: Foo := Foo(value => 10);
-        borrow! foo as fooref in R do
+        borrow fooref: &![Foo, R] := &!foo do
             borrow~ fooref as fooref2a in R2 do
                 show(fooref2a);
             end;
@@ -22,7 +22,7 @@ module body Test is
             borrow~ fooref as fooref2c in R2 do
                 show(fooref2c);
             end;
-        end;
+        end borrow;
         let { value: Int32 } := foo;
         return ExitSuccess();
     end;

--- a/test-programs/suites/007-borrowing/016-borrow-free/Test.aum
+++ b/test-programs/suites/007-borrowing/016-borrow-free/Test.aum
@@ -1,9 +1,9 @@
 module body Test is
     function main(): ExitCode is
         let foo: Unit := nil;
-        borrow foo as fooref in R do
+        borrow fooref: &[Foo, R] := &foo do
             skip;
-        end;
+        end borrow;
         return ExitSuccess();
     end;
 end module body.

--- a/test-programs/suites/008-typeclasses/001-trivial-typeclass/Test.aum
+++ b/test-programs/suites/008-typeclasses/001-trivial-typeclass/Test.aum
@@ -47,9 +47,9 @@ module body Test is
         PrintF('a' : Nat16);
         PrintF(3.14);
         let foo: Foo := Foo();
-        borrow foo as fooref in rho do
+        borrow fooref: &[Foo, rho] := &foo do
             PrintF(fooref);
-        end;
+        end borrow;
         PrintF(&foo);
         let {} := foo;
         return ExitSuccess();

--- a/test-programs/suites/011-bugs/github-413/Test.aum
+++ b/test-programs/suites/011-bugs/github-413/Test.aum
@@ -14,13 +14,13 @@ module body Test is
 
     function main(): ExitCode is
         let u: Foo := Value(value => 123);
-        borrow u as uref in R do
+        borrow uref: &[Foo, R] := &u do
             case uref of
                 when Value(value: &[Int32, R]) do
                     let i: Int32 := !value;
                     printLn(i);
             end case;
-        end;
+        end borrow;
         consume(u);
         return ExitSuccess();
     end;

--- a/test-programs/suites/013-ref-transforms/002-not-a-record/Test.aum
+++ b/test-programs/suites/013-ref-transforms/002-not-a-record/Test.aum
@@ -5,9 +5,9 @@ module body Test is
 
     function main(): ExitCode is
         let foo: Foo := Blank();
-        borrow foo as fooref in R do
+        borrow fooref: &[Foo, R] := &foo do
             &(fooref->foo);
-        end;
+        end borrow;
         case foo of
             when Blank do
                 skip;

--- a/test-programs/suites/013-ref-transforms/002-not-a-record/austral-stderr.txt
+++ b/test-programs/suites/013-ref-transforms/002-not-a-record/austral-stderr.txt
@@ -13,9 +13,9 @@
   },
   "context": [
     [ 7, "        let foo: Foo := Blank();" ],
-    [ 8, "        borrow foo as fooref in R do" ],
+    [ 8, "        borrow fooref: &[Foo, R] := &foo do" ],
     [ 9, "            &(fooref->foo);" ],
-    [ 10, "        end;" ],
+    [ 10, "        end borrow;" ],
     [ 11, "        case foo of" ]
   ]
 }

--- a/test-programs/suites/013-ref-transforms/003-read-refs/Test.aum
+++ b/test-programs/suites/013-ref-transforms/003-read-refs/Test.aum
@@ -17,7 +17,7 @@ module body Test is
         let bar: Bar := Bar(baz => baz);
         let foo: Foo := Foo(bar => bar);
         -- Borrow.
-        borrow foo as fooref in R do
+        borrow fooref: &[Foo, R] := &foo do
             -- Direct.
             let a: &[Bar, R] := &(fooref->bar);
             let b: &[Baz, R] := &(fooref->bar->baz);
@@ -27,7 +27,7 @@ module body Test is
             let d: &[Baz, R] := &(a->baz);
             let e: &[Int32, R] := &(d->i);
             printLn(!e);
-        end;
+        end borrow;
         -- Destructure.
         let { bar as bar2: Bar } := foo;
         let { baz as baz2: Baz } := bar2;

--- a/test-programs/suites/015-mutability/003-cant-mutborrow-let/Test.aum
+++ b/test-programs/suites/015-mutability/003-cant-mutborrow-let/Test.aum
@@ -3,9 +3,9 @@ module body Test is
 
     function main(): ExitCode is
         let foo: Foo := Foo();
-        borrow! foo as fooref in R do
+        borrow fooref: &![Foo, R] := &!foo do
             skip;
-        end;
+        end borrow;
         let {} := foo;
         return ExitSuccess();
     end;

--- a/test-programs/suites/015-mutability/003-cant-mutborrow-let/austral-stderr.txt
+++ b/test-programs/suites/015-mutability/003-cant-mutborrow-let/austral-stderr.txt
@@ -12,14 +12,14 @@
   "span": {
     "filename": "test-programs/suites/015-mutability/003-cant-mutborrow-let/Test.aum",
     "startp": { "line": 6, "column": 8 },
-    "end": { "line": 8, "column": 12 }
+    "end": { "line": 8, "column": 19 }
   },
   "context": [
     [ 4, "    function main(): ExitCode is" ],
     [ 5, "        let foo: Foo := Foo();" ],
-    [ 6, "        borrow! foo as fooref in R do" ],
+    [ 6, "        borrow fooref: &![Foo, R] := &!foo do" ],
     [ 7, "            skip;" ],
-    [ 8, "        end;" ],
+    [ 8, "        end borrow;" ],
     [ 9, "        let {} := foo;" ],
     [ 10, "        return ExitSuccess();" ]
   ]

--- a/test-programs/suites/016-spans/002-get-span/Test.aum
+++ b/test-programs/suites/016-spans/002-get-span/Test.aum
@@ -29,10 +29,10 @@ module body Test is
             let sp: Span[Int32, R] := span(ref, 0, 9);
             printLn(spanLength(sp));
         end borrow;
-        borrow! ptr as ref2 in R do
+        borrow ref2: &![Pointer[Int32], R] := &!ptr do
             let sp2: Span![Int32, R] := spanWrite(ref2, 0, 9);
             printLn(spanWriteLength(sp2));
-        end;
+        end borrow;
         deallocate(ptr);
         let addr: Address[Int32] := allocateBuffer(10);
         return ExitSuccess();

--- a/test-programs/suites/016-spans/002-get-span/Test.aum
+++ b/test-programs/suites/016-spans/002-get-span/Test.aum
@@ -25,10 +25,10 @@ module body Test is
 
     function main(): ExitCode is
         var ptr: Pointer[Int32] := allocateOrDie();
-        borrow ptr as ref in R do
+        borrow ref: &[Pointer[Int32], R] := &ptr do
             let sp: Span[Int32, R] := span(ref, 0, 9);
             printLn(spanLength(sp));
-        end;
+        end borrow;
         borrow! ptr as ref2 in R do
             let sp2: Span![Int32, R] := spanWrite(ref2, 0, 9);
             printLn(spanWriteLength(sp2));


### PR DESCRIPTION
Before:

```austral
-- Immutable borrow
borrow foo as bar in R do
  -- etc.
end;

-- Mutable borrow
borrow! foo as bar in R do
  -- etc.
end;

-- Reborrow
borrow~ foo as bar in R do
  -- etc.
end;
```

Now:

```austral
-- Immutable borrow
borrow foo: &[T, R] := &bar do
  -- etc.
end borrow;

-- Mutable borrow
borrow foo: &![T, R] := &!bar do
  -- etc.
end borrow;

-- Reborrow
borrow foo: &[T, R] := &~bar do
  -- etc.
end borrow;
```

Pros:
1. Types are written down.
2. More consistent, less English-y.
3. `end borrow` rather than a bare `end`.
Cons:
1. More wordy.

See also: https://github.com/austral/austral/discussions/479