### PR TITLE
Add flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ error.html
 *~
 lib/BuiltInModules.ml
 FAILURES.txt
+result

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BIN := austral
 SRC := lib/*.ml lib/*.mli lib/*.mll lib/*.mly lib/dune bin/dune bin/austral.ml lib/BuiltInModules.ml
+PREFIX ?= /usr/local
 
 .PHONY: all
 all: $(BIN)
@@ -17,11 +18,11 @@ test: $(BIN)
 
 .PHONY: install
 install: $(BIN)
-	install -m 755 austral /usr/local/bin/austral
+	install -D -m 755 austral $(PREFIX)/bin/austral
 
 .PHONY: uninstall
 uninstall:
-	sudo rm /usr/local/bin/austral
+	sudo rm $(PREFIX)/bin/austral
 
 .PHONY: clean
 clean:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1689503327,
+        "narHash": "sha256-qVwzYLA8oT2oWNDXO0A3bZHOhoPOihIB9T677+Hor1E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f64b9738da8e86195766147e9752c67fccee006c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -35,10 +35,6 @@
           version = "0.2.0";
           src = ./.;
           inherit buildInputs;
-          buildPhase = ''
-            make
-          '';
-
           installPhase = ''
             mkdir -p $out/bin
             install -m 755 austral $out/bin/austral

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Systems language with linear types and capability-based security.";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+  inputs.utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, utils }: 
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        buildInputs = with pkgs; [
+          # General
+          gmp
+          python311
+
+          # Tooling
+          ocamlPackages.ocaml
+          ocamlPackages.dune_3
+          ocamlPackages.findlib
+          ocamlPackages.odoc
+
+          # OCaml libraries
+          ocamlPackages.yojson
+          ocamlPackages.ppx_deriving
+          ocamlPackages.ounit2
+          ocamlPackages.menhir
+          ocamlPackages.sexplib
+          ocamlPackages.ppx_sexp_conv
+          ocamlPackages.zarith
+        ];
+
+      in {
+        packages.default = pkgs.stdenv.mkDerivation {
+          name = "austral";
+          src = ./.;
+          inherit buildInputs;
+          buildPhase = ''
+            make
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            install -m 755 austral $out/bin/austral
+          '';
+        };
+
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs;
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,11 +34,8 @@
           pname = "austral";
           version = "0.2.0";
           src = ./.;
+          installFlags = [ "PREFIX=$(out)" ];
           inherit buildInputs;
-          installPhase = ''
-            mkdir -p $out/bin
-            install -m 755 austral $out/bin/austral
-          '';
         };
 
         devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,8 @@
 
       in {
         packages.default = pkgs.stdenv.mkDerivation {
-          name = "austral";
+          pname = "austral";
+          version = "0.2.0";
           src = ./.;
           inherit buildInputs;
           buildPhase = ''


### PR DESCRIPTION
- Create flake.nix with
  - default package - can be built and ran with `nix build` and `nix run`
  - default devShell - enter with `nix develop`. I decided not to import the existing `shell.nix` since it's trivial, although I could if you prefer.
- add `PREFIX` to Makefile to support installing to different locations (eg nix store)
- add nix's `result` symlink to the `.gitignore`