### PR TITLE
austral-mode: indent function body too. Fix #568.

### DIFF
--- a/editor/austral-mode.el
+++ b/editor/austral-mode.el
@@ -67,7 +67,7 @@ If there are no blank-lines, returns zero and the empty string."
      ((string= previous-text "")
       ;; This case represents the beginning of the buffer. So we indent to zero.
       (indent-line-to 0))
-     ((string-match "^[ \t]*\\(module\\|import\\|record\\|union\\|interface\\|if\\|else\\|for\\|while\\|borrow\\)" previous-text)
+     ((string-match "^[ \t]*\\(module\\|import\\|record\\|union\\|interface\\|function\\|if\\|else\\|for\\|while\\|borrow\\)" previous-text)
       ;; The previous line opens a new indent block.
       (indent-line-to (+ austral-default-tab-width previous-indent)))
      ((string-match "^[ \t]*\\(end\\|\\\\);\\)" previous-text)


### PR DESCRIPTION
This fixes #568.

Before:
![austral-mode-before](https://github.com/austral/austral/assets/2456465/9fea7d0f-72ea-4660-9238-728a07a6a247)

After:
![austral-mode-after](https://github.com/austral/austral/assets/2456465/96275f0c-cdc7-4754-a994-fad441fd1e40)
