### PR TITLE
Add suggested solution to error message.

### DIFF
--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -55,11 +55,13 @@ let cannot_borrow_immutable_var_mutably (name: identifier) =
       Text " mutably because the variable is immutable."
     ]
 
-let cannot_borrow_param_mutably (name: identifier) =
+let cannot_borrow_param_mutably (name: identifier) (ty: ty) =
   austral_raise TypeError [
       Text "Cannot borrow the variable ";
       Code (ident_string name);
-      Text " mutably because it is a function parameter, and therefore immutable."
+      Text " mutably because it is a function parameter, and therefore immutable.";
+      Text "\nYou can move it to a mutable local variable: ";
+      Code ("var mut_" ^ (ident_string name) ^ ": " ^ (type_string ty) ^ " := " ^ (ident_string name) ^ ";");
     ]
 
 let call_non_callable ty =

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -331,7 +331,7 @@ let rec augment_stmt (ctx: stmt_ctx) (stmt: astmt): tstmt =
                       if is_mut then
                         ()
                       else
-                        Errors.cannot_borrow_param_mutably original
+                        Errors.cannot_borrow_param_mutably original orig_ty
                    | _ ->
                       (* And anything else is fine. *)
                       ()


### PR DESCRIPTION
The error message looks like this:
```
  Description:
    Cannot borrow the variable `root` mutably because it is a function parameter, and therefore immutable.
    You can move it to a mutable local variable: `var mut_root: RootCapability := root;`
  Code:
    24 |     function main(root: RootCapability): ExitCode is
    25 |         printLn("Hello, world!");
    26 |         var term: TerminalCapability := acquireTerminal(&!root);
    27 |         releaseTerminal(term);
    28 |         return ExitSuccess();
```