### PR TITLE
Error messages: add details to error about enum slots mismatch.

### DIFF
--- a/lib/TypeErrors.ml
+++ b/lib/TypeErrors.ml
@@ -102,9 +102,13 @@ let case_non_union ty =
     Text " which is not a union type."
   ]
 
-let case_wrong_slots () =
+let case_wrong_slots (binding_names, slot_names) =
   austral_raise TypeError [
-    Text "The set of slots in the case statement doesn't match the set of slots in the union definition."
+    Text "The set of slots (";
+    Code (String.concat ", " binding_names);
+    Text ") in the case statement doesn't match the set of slots in the union definition (";
+    Code (String.concat ", " slot_names);
+    Text ")."
   ]
 
 let cast_different_references ~different_types ~different_regions =

--- a/lib/TypingPass.ml
+++ b/lib/TypingPass.ml
@@ -524,7 +524,7 @@ and augment_when (ctx: stmt_ctx) (typebindings: type_bindings) (w: abstract_when
         remove_vars lexenv (List.map (fun (n, _, _) -> n) newvars);
         TypedWhen (name, List.map (fun (name, _, ty, rename) -> TypedBinding { name; ty; rename}) bindings'', body')
       else
-        Errors.case_wrong_slots ())
+        Errors.case_wrong_slots (List.map ident_string binding_names, List.map ident_string slot_names))
 
 let rec validate_constant_expression (expr: texpr): unit =
   if is_constant expr then


### PR DESCRIPTION
Original message:
```
  Description:
    The set of slots in the case statement doesn't match
the set of slots in the union definition:
  Code:
     7 |         let integer: Int32 := 1234;
     8 |         printLn(integer);
     9 |         case toFloat64(integer) of
    10 |             when Some(float: Float64) do
    11 |                 printLn(float);
    12 |                 printLn(float/3);
    13 |             when None do
    14 |                 printLn("Failed to convert number.");
    15 |         end case;
    16 |         surrenderRoot(mut_root);
    17 |         return ExitSuccess();
```
After this change:
```
  Description:
    The set of slots (`float`) in the case statement doesn't match
the set of slots in the union definition (`value`).
  Code:
     7 |         let integer: Int32 := 1234;
     8 |         printLn(integer);
     9 |         case toFloat64(integer) of
    10 |             when Some(float: Float64) do
    11 |                 printLn(float);
    12 |                 printLn(float/3);
    13 |             when None do
    14 |                 printLn("Failed to convert number.");
    15 |         end case;
    16 |         surrenderRoot(mut_root);
    17 |         return ExitSuccess();
```