### PR TITLE
add Example.Greet

### DIFF
--- a/examples/greet/Greet.aui
+++ b/examples/greet/Greet.aui
@@ -1,0 +1,3 @@
+module Example.Greet is
+    function main(root: RootCapability): ExitCode;
+end module.

--- a/examples/greet/Greet.aum
+++ b/examples/greet/Greet.aum
@@ -1,0 +1,38 @@
+import Standard.IO (
+    acquireTerminal,
+    releaseTerminal,
+    TerminalCapability,
+    readByte
+);
+import Standard.IO.Terminal (
+    StandardInput,
+    acquireInput,
+    releaseInput,
+    readLine
+);
+import Standard.String (
+    String, 
+    destroyString, 
+    getSpan,
+    length
+);
+
+module body Example.Greet is
+    function main(root: RootCapability): ExitCode is
+        var mutRoot: RootCapability := root;
+        var terminal: TerminalCapability := acquireTerminal(&!mutRoot);
+        var input: StandardInput := acquireInput(&!terminal);
+
+        let line: String := readLine(&!input);
+        print("Hello, ");
+        print(getSpan(&line, 0, length(&line) - 1));
+        printLn("!");
+
+        destroyString(line);
+        releaseInput(input);
+        releaseTerminal(terminal);
+        surrenderRoot(mutRoot); 
+        return ExitSuccess();
+    end;
+end module body.
+

--- a/run-examples.sh
+++ b/run-examples.sh
@@ -9,8 +9,22 @@ set -euxo pipefail
 dune build
 
 function compile() {
-    ./austral compile $1/$2.aui,$1/$2.aum --entrypoint=Example.$2:main --output=testbin
-    ./testbin > actual.txt
+    ./austral compile \
+        ./standard/src/Buffer.aui,./standard/src/Buffer.aum \
+        ./standard/src/String.aui,./standard/src/String.aum \
+        ./standard/src/StringBuilder.aui,./standard/src/StringBuilder.aum \
+        ./standard/src/IO/IO.aui,./standard/src/IO/IO.aum \
+        ./standard/src/IO/Terminal.aui,./standard/src/IO/Terminal.aum \
+        $1/$2.aui,$1/$2.aum \
+        --entrypoint=Example.$2:main --output=testbin
+
+    if [ $# -eq 4 ] 
+    then
+        echo -n -e $4 | ./testbin > actual.txt
+    else
+        ./testbin > actual.txt
+    fi
+
     echo -n -e "$3" > expected.txt
     diff actual.txt expected.txt
     rm testbin
@@ -29,3 +43,4 @@ compile examples/memory Memory ""
 compile examples/named-argument NamedArgument ""
 compile examples/record Record ""
 compile examples/union Union ""
+compile examples/greet Greet "Hello, Santa!\n" "Santa"


### PR DESCRIPTION
fixes #545

I have had to modify the run-examples.sh to use the stdlib and to provide some input to stdin.

This example doesn't actually work correctly yet because Standard.IO.Terminal.readLine doesn't work correctly, see #577.