### PR TITLE
austral-mode: correct indentation for `else`.

### DIFF
--- a/editor/austral-mode.el
+++ b/editor/austral-mode.el
@@ -34,7 +34,7 @@
 (defconst austral-deindent-2-regexp
   "^[ \t]*\\(end case;\\)")
 (defconst austral-deindent-1-regexp
-  "^[ \t]*\\(end[ \t_[:alnum:]]*[;.]\\|[)];\\|when\\>\\)")
+  "^[ \t]*\\(end[ \t_[:alnum:]]*[;.]\\|[)];\\|when\\>\\|else\\>\\)")
 
 (defconst austral-default-tab-width 4)
 


### PR DESCRIPTION
Can be tested on `examples/fib/Fibonacci.aum`.