### PR TITLE
Correct integer encoding of '\n' newline char constant literal.

### DIFF
--- a/lib/Util.ml
+++ b/lib/Util.ml
@@ -116,7 +116,7 @@ let parse_oct (s: string): int =
 let parse_ascii_char (s: string): int =
   match s with
   | "\\n" ->
-     97
+     10
   | "\\r" ->
      13
   | "\\t" ->


### PR DESCRIPTION
I do not see any reason for encoding `'\n'` as 97 when the other characters match their ASCII code so I assume this was a typo, but again I’m not familiar with OCaml and there might be some reason behind this.

If it was a typo, this fixes #577.