### PR TITLE
Fix `fromLiteral` for empty string

### DIFF
--- a/standard/src/String.aum
+++ b/standard/src/String.aum
@@ -42,9 +42,11 @@ module body Standard.String is
     function fromLiteral(arr: Span[Nat8, Static]): String is
         let size: Index := spanLength(arr);
         var str: String := makeString(size, ' ');
-        for i from 0 to size - 1 do
-            storeNth(&!str, i, arr[i]);
-        end for;
+        if size > 0 then
+            for i from 0 to size - 1 do
+                storeNth(&!str, i, arr[i]);
+            end for;
+        end if;
         return str;
     end;
 

--- a/standard/test/String.aum
+++ b/standard/test/String.aum
@@ -28,6 +28,7 @@ module body Standard.Test.String is
         makeEmptyTest();
         makeStringTest();
         fromLiteralTest();
+        fromLiteralEmptyTest();
         storeNthTest();
         return nil;
     end;
@@ -71,6 +72,15 @@ module body Standard.Test.String is
         assertTrue(nthByte(&s, 10) = 'l', "[10] = l");
         assertTrue(nthByte(&s, 11) = 'd', "[11] = d");
         assertTrue(nthByte(&s, 12) = '!', "[12] = !");
+        destroyString(s);
+        assertSuccess("destroyString complete");
+        return nil;
+    end;
+
+    function fromLiteralEmptyTest(): Unit is
+        testHeading("fromLiteral empty");
+        let s: String := fromLiteral("");
+        assertLength(&s, 0);
         destroyString(s);
         assertSuccess("destroyString complete");
         return nil;


### PR DESCRIPTION
As demonstrated by the added test case, currently `fromLiteral` aborts with the following error message when given an empty string:

```
Overflow in trappingSubtract (Index)
```

This PR fixes the bug by adding a check for zero size.

Incidentally, this really makes me think that it's unwise for the `for` loop to be inclusive on both ends, since it means that every `for` loop that doesn't want to crash on the zero case must special-case it. Since `Index` is unsigned, wouldn't it make more sense to provide a way to do an inclusive-exclusive range, like most languages do? E.g., Rust:

```rust
for i in 0..size {
    // ...
}
```