### PR TITLE
Run CI on PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,9 @@
 name: Build and Test
 on:
-  - push
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build-and-test-linux:


### PR DESCRIPTION
Similar to #593, it'd be nice if the "Build and Test" workflow ran on PRs, so that contributors can tell whether a PR passes the tests before merging.