### PR TITLE
Add Makefiles to examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,27 @@
+.DEFAULT: all
+all: 
+	cd ffi && $(MAKE)
+	cd fib && $(MAKE)
+	cd generic-record && $(MAKE)
+	cd greet && $(MAKE)
+	cd haversine && $(MAKE)
+	cd hello-world && $(MAKE)
+	cd identity && $(MAKE)
+	cd memory && $(MAKE)
+	cd named-argument && $(MAKE)
+	cd record && $(MAKE)
+	cd union && $(MAKE)
+
+.PHONY: clean
+clean:
+	cd ffi && $(MAKE) clean
+	cd fib && $(MAKE) clean
+	cd generic-record && $(MAKE) clean
+	cd greet && $(MAKE) clean
+	cd haversine && $(MAKE) clean
+	cd hello-world && $(MAKE) clean
+	cd identity && $(MAKE) clean
+	cd memory && $(MAKE) clean
+	cd named-argument && $(MAKE) clean
+	cd record && $(MAKE) clean
+	cd union && $(MAKE) clean

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Austral Examples
+
+This directory contains examples of Austral programs. To build all examples, run `make` in this directory. An executable called `main` will be built in each directory. To build an individual example, `cd` into that directory and run `make`. 

--- a/examples/ffi/Makefile
+++ b/examples/ffi/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := FFI
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/fib/Makefile
+++ b/examples/fib/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := Fibonacci
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/generic-record/Makefile
+++ b/examples/generic-record/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := GenericRecord
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/generic-union/Makefile
+++ b/examples/generic-union/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := GenericUnion
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/greet/Makefile
+++ b/examples/greet/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := Greet
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/haversine/Makefile
+++ b/examples/haversine/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := Haversine
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := HelloWorld
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/identity/Makefile
+++ b/examples/identity/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := Identity
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/memory/Makefile
+++ b/examples/memory/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := Memory
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/named-argument/Makefile
+++ b/examples/named-argument/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := NamedArgument
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/record/Makefile
+++ b/examples/record/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := Record
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main

--- a/examples/union/Makefile
+++ b/examples/union/Makefile
@@ -1,0 +1,26 @@
+STDLIB := \
+		../../standard/src/Tuples.aui,../../standard/src/Tuples.aum \
+		../../standard/src/Bounded.aui,../../standard/src/Bounded.aum \
+		../../standard/src/Equality.aui,../../standard/src/Equality.aum \
+		../../standard/src/Order.aui,../../standard/src/Order.aum \
+		../../standard/src/Box.aui,../../standard/src/Box.aum \
+		../../standard/src/Buffer.aui,../../standard/src/Buffer.aum \
+		../../standard/src/String.aui,../../standard/src/String.aum \
+		../../standard/src/StringBuilder.aui,../../standard/src/StringBuilder.aum \
+		../../standard/src/IO/IO.aui,../../standard/src/IO/IO.aum \
+		../../standard/src/IO/Terminal.aui,../../standard/src/IO/Terminal.aum \
+		
+PROG := Union
+
+ENTRY := Example.$(PROG):main
+
+SRC := \
+	$(PROG).aui,$(PROG).aum
+
+.DEFAULT: all
+all: 
+	../../austral compile $(STDLIB) $(SRC) --entrypoint=$(ENTRY) --output=main
+
+.PHONY: clean
+clean:
+	rm main


### PR DESCRIPTION
Building the examples presents a source of friction to new users who want to experiment with the language. This is especially true when an example needs to be compiled with the standard library. This commit adds a standard Makefile for examples to make them easy to build and provides a template for adding new examples.