### PR TITLE
Replace magic-nix-cache-action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,10 +18,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: install nix
-        uses: DeterminateSystems/nix-installer-action@v4
+        uses: nixbuild/nix-quick-install-action@v30
 
       - name: nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v1
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
 
       - name: set up nix shell
         run: nix-shell --command 'true'


### PR DESCRIPTION
The `DeterminateSystems/magic-nix-cache-action` action has been [deprecated](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) and no longer works. This PR replaces it with the `nix-community/cache-nix-action` action, which is actively maintained. It also replaces the `DeterminateSystems/nix-installer-action` action with the `nixbuild/nix-quick-install-action` action, which is required for the cache action to work. The cache has been configured to restore based on the runner's OS and architecture, so it should work on any runner.
