### PR TITLE
Upgrade actions/upload-artifact action to v4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
         run: nix-shell --command './standard/test_bin'
 
       - name: upload compiler binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: austral-linux-bin
           path: austral


### PR DESCRIPTION
When I submitted my previous PR #613, I noticed the CI was failing because the `actions/upload-artifact` action was on v2, which is deprecated and no longer works, so this PR bumps it to v4 which is the latest version.