### PR TITLE
Fix Bugs in Buffer stdlib impl

### DIFF
--- a/austral.opam
+++ b/austral.opam
@@ -7,7 +7,7 @@ homepage: "https://austral-lang.org/"
 bug-reports: "https://github.com/austral/austral/issues"
 depends: [
   "dune" {>= "2.1"}
-  "ppxlib" {= "0.25.0"}
+  "ppxlib" {>= "0.25.1"}
   "ppx_deriving" {= "5.2.1"}
   "ppx_sexp_conv" {= "v0.15.0"}
   "sexplib" {= "v0.15.1"}

--- a/dune-project
+++ b/dune-project
@@ -11,7 +11,7 @@
  (homepage https://austral-lang.org/)
  (bug_reports https://github.com/austral/austral/issues)
  (depends
-  (ppxlib (= 0.25.0))
+  (ppxlib (>= 0.25.1))
   (ppx_deriving (= 5.2.1))
   (ppx_sexp_conv (= v0.15.0))
   (sexplib (= v0.15.1))

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -56,11 +56,11 @@ module body Standard.Buffer is
     function invariants(buf: &[Buffer[T], R]): Unit is
         -- Size is always strictly less than the capacity. When resizing, if
         -- the size matches the capacity, we bump up.
-        if buf->size >= buf->size then
+        if buf->size >= buf->capacity then
             abort("Buffer size >= capacity");
         end if;
         -- Capacity is always non-zero.
-        if buf->size = 0 then
+        if buf->capacity = 0 then
             abort("Buffer capacity = 0");
         end if;
         return nil;
@@ -272,7 +272,7 @@ module body Standard.Buffer is
     """
     generic [T: Type, R: Region]
     function bump(buf: &![Buffer[T], R]): Unit is
-        let new_capacity: Index := buf->size * 2;
+        let new_capacity: Index := buf->capacity * 2;
         let new_addr: Address[T] := resizeArray(buf->array, new_capacity);
         case nullCheck(new_addr) of
             when Some(value as new_array: Pointer[T]) do
@@ -298,7 +298,7 @@ module body Standard.Buffer is
         end if;
         -- If insertion would increase make `size` match `capacity`, resize
         -- the array.
-        if (buf->size + 1) = buf->size then
+        if (buf->size + 1) = buf->capacity then
             bump(&~buf);
         end if;
         -- If the array is non-empty, we have to move everything to the right of
@@ -377,8 +377,8 @@ module body Standard.Buffer is
 
     generic [T: Type, R: Region]
     function reverse(buf: &![Buffer[T], R]): Unit is
-        if buf->size > 0 then
-            for i from 0 to buf->size / 2 do
+        if buf->size > 1 then
+            for i from 0 to (buf->size / 2) - 1 do
                 let j: Index := (buf->size - i) - 1;
                 swapIndex(&~buf, i, j);
             end for;

--- a/standard/test/Buffer.aum
+++ b/standard/test/Buffer.aum
@@ -460,16 +460,6 @@ module body Standard.Test.Buffer is
     --- Regression Tests for Bug Fixes
     ---
 
-    -- Helper function to convert Index to Int32 for tests
-    function indexToInt32(idx: Index): Int32 is
-        case toInt32(idx) of
-            when Some(value: Int32) do
-                return value;
-            when None do
-                abort("Index value too large for Int32");
-        end case;
-    end;
-
     function reverseEvenNumberTest(): Unit is
         testHeading("reverse even number of elements");
         var b: Buffer[Int32] := allocateEmpty();
@@ -612,5 +602,15 @@ module body Standard.Test.Buffer is
     function assertNth(ref: &[Buffer[T], R], pos: Index, value: T): Unit is
         assertTrue(nth(ref, pos) = value, "nth");
         return nil;
+    end;
+
+    -- Helper function to convert Index to Int32 for tests
+    function indexToInt32(idx: Index): Int32 is
+        case toInt32(idx) of
+            when Some(value: Int32) do
+                return value;
+            when None do
+                abort("Index value too large for Int32");
+        end case;
     end;
 end module body.

--- a/standard/test/Buffer.aum
+++ b/standard/test/Buffer.aum
@@ -60,6 +60,14 @@ module body Standard.Test.Buffer is
         mapEmptyTest();
         getSpanTest();
         getSpanMutTest();
+        
+        -- New regression tests for specific bug fixes
+        reverseEvenNumberTest();
+        reverseOddNumberTest();
+        insertCapacityResizeTest();
+        capacityGrowthTest();
+        edgeCaseInvariantsTest();
+        
         return nil;
     end;
 
@@ -445,6 +453,148 @@ module body Standard.Test.Buffer is
         -- Destroy.
         destroyFree(b);
 
+        return nil;
+    end;
+
+    ---
+    --- Regression Tests for Bug Fixes
+    ---
+
+    -- Helper function to convert Index to Int32 for tests
+    function indexToInt32(idx: Index): Int32 is
+        case toInt32(idx) of
+            when Some(value: Int32) do
+                return value;
+            when None do
+                abort("Index value too large for Int32");
+        end case;
+    end;
+
+    function reverseEvenNumberTest(): Unit is
+        testHeading("reverse even number of elements");
+        var b: Buffer[Int32] := allocateEmpty();
+        insertBack(&!b, 1);
+        insertBack(&!b, 2);
+        insertBack(&!b, 3);
+        insertBack(&!b, 4);
+        -- [1,2,3,4]
+        assertLength(&b, 4);
+        assertNth(&b, 0, 1);
+        assertNth(&b, 1, 2);
+        assertNth(&b, 2, 3);
+        assertNth(&b, 3, 4);
+        reverse(&!b);
+        -- [4,3,2,1]
+        assertLength(&b, 4);
+        assertNth(&b, 0, 4);
+        assertNth(&b, 1, 3);
+        assertNth(&b, 2, 2);
+        assertNth(&b, 3, 1);
+        destroyFree(b);
+        return nil;
+    end;
+
+    function reverseOddNumberTest(): Unit is
+        testHeading("reverse odd number of elements");
+        var b: Buffer[Int32] := allocateEmpty();
+        insertBack(&!b, 1);
+        insertBack(&!b, 2);
+        insertBack(&!b, 3);
+        insertBack(&!b, 4);
+        insertBack(&!b, 5);
+        -- [1,2,3,4,5]
+        assertLength(&b, 5);
+        reverse(&!b);
+        -- [5,4,3,2,1]
+        assertLength(&b, 5);
+        assertNth(&b, 0, 5);
+        assertNth(&b, 1, 4);
+        assertNth(&b, 2, 3);  -- Middle element
+        assertNth(&b, 3, 2);
+        assertNth(&b, 4, 1);
+        destroyFree(b);
+        return nil;
+    end;
+
+    function insertCapacityResizeTest(): Unit is
+        testHeading("insert capacity resize");
+        var b: Buffer[Int32] := allocateEmpty();
+        
+        -- Fill to near capacity
+        for i from 0 to 14 do
+            insertBack(&!b, indexToInt32(i));
+        end for;
+        
+        assertLength(&b, 15);
+        
+        -- Trigger resize
+        insertBack(&!b, 15);
+        assertLength(&b, 16);
+        assertNth(&b, 15, 15);
+        
+        -- Trigger another resize
+        insertBack(&!b, 16);
+        assertLength(&b, 17);
+        assertNth(&b, 16, 16);
+        
+        destroyFree(b);
+        return nil;
+    end;
+
+    function capacityGrowthTest(): Unit is
+        testHeading("capacity growth calculation");
+        var b: Buffer[Int32] := allocateEmpty();
+        
+        -- Force multiple resizes
+        for i from 0 to 100 do
+            insertBack(&!b, indexToInt32(i));
+        end for;
+        
+        assertLength(&b, 101);
+        
+        -- Verify all elements preserved
+        for i from 0 to 100 do
+            assertTrue(nth(&b, i) = indexToInt32(i), "Element at index preserved after resizes");
+        end for;
+        
+        destroyFree(b);
+        return nil;
+    end;
+
+    function edgeCaseInvariantsTest(): Unit is
+        testHeading("edge case invariants");
+        
+        -- Empty buffer
+        let b1: Buffer[Int32] := allocateEmpty();
+        assertLength(&b1, 0);
+        destroyEmpty(b1);
+        
+        -- Single element buffer
+        var b2: Buffer[Int32] := initialize(1, 42);
+        assertLength(&b2, 1);
+        assertNth(&b2, 0, 42);
+        
+        insertBack(&!b2, 43);
+        assertLength(&b2, 2);
+        assertNth(&b2, 1, 43);
+        
+        destroyFree(b2);
+        
+        -- Minimum capacity boundary
+        var b3: Buffer[Int32] := allocateEmpty();
+        for i from 0 to 15 do
+            insertBack(&!b3, indexToInt32(i * 10));
+        end for;
+        
+        assertLength(&b3, 16);
+        
+        for i from 0 to 15 do
+            assertTrue(nth(&b3, i) = indexToInt32(i * 10), "Minimum capacity boundary test");
+        end for;
+        
+        destroyFree(b3);
+        
+        assertSuccess("Edge case invariants passed");
         return nil;
     end;
 


### PR DESCRIPTION
This PR fixes the below bugs in the Buffer stdlib implementation and adds tests to catch future regressions.

### OB1 (off by one) bug in `reverse()`
A bug in reverse caused corruption in even sized buffers.
Existing stdlib testing suite only used empty or odd sized buffers hence why it was never caught.

### Size check in `invariants()`
A bug in invariants could cause a buffer to overrun it's allocated memory.
We were checking for `buf->size >= buf->size` which is always true.
We should be checking for `buf->size >= buf->capacity` instead.

### Capacity check in `invariants()`
We were checking for `buf->size = 0` which does not take into account allocated memory.
We should be checking for `buf->capacity = 0` instead.

### Capacity check in `insert()`
We were checking for `(buf->size + 1) = buf->size` which is a mathematical impossibility.
This could cause insert to write beyond the buffer's allocated memory.
We should be checking for `(buf->size + 1) = buf->capacity` instead.

### Capacity calculation in `bump()`
We were calculating new capacity based off of size.
We should be calculating new capacity based off of capacity instead.

Cheers.