### PR TITLE
Implement Primitive Equality/Order and Fix Buffer Resizing (#619)

### DIFF
--- a/standard/Makefile
+++ b/standard/Makefile
@@ -22,8 +22,16 @@ MODULES := \
 		test/Main.aui,test/Main.aum
 TEST_BIN := test_bin
 
-.DEFAULT: all
-all: $(TEST_BIN)
+.DEFAULT_GOAL := all
+.PHONY: all build test test-all
+all: test-all
+
+build: $(TEST_BIN)
+
+test: test-all
+
+test-all: $(TEST_BIN)
+	./$(TEST_BIN)
 
 $(TEST_BIN): src/*.aui src/*.aum src/*/*.aui src/*/*.aum test/*.aui test/*.aum test/*/*.aui test/*/*.aum
 	../austral compile $(MODULES) --entrypoint=Standard.Test:Main --output=$(TEST_BIN)

--- a/standard/src/Buffer.aum
+++ b/standard/src/Buffer.aum
@@ -17,7 +17,6 @@ import Austral.Memory (
     negativeOffset,
     store,
     load,
-    memcpy,
     memmove,
     arraySizeInBytes,
     span,
@@ -276,11 +275,6 @@ module body Standard.Buffer is
         let new_addr: Address[T] := resizeArray(buf->array, new_capacity);
         case nullCheck(new_addr) of
             when Some(value as new_array: Pointer[T]) do
-                memcpy(
-                    destination => new_array,
-                    source => buf->array,
-                    count => arraySizeInBytes(sizeof(T), buf->size)
-                );
                 buf->capacity := new_capacity;
                 buf->array := new_array;
                 -- invariants(buf : &[Buffer[T], R]);

--- a/standard/src/Equality.aui
+++ b/standard/src/Equality.aui
@@ -27,4 +27,24 @@ module Standard.Equality is
 
     instance PartialEquality(Unit);
     instance Equality(Unit);
+    instance PartialEquality(Bool);
+    instance Equality(Bool);
+    instance PartialEquality(Nat8);
+    instance Equality(Nat8);
+    instance PartialEquality(Nat16);
+    instance Equality(Nat16);
+    instance PartialEquality(Nat32);
+    instance Equality(Nat32);
+    instance PartialEquality(Nat64);
+    instance Equality(Nat64);
+    instance PartialEquality(Int8);
+    instance Equality(Int8);
+    instance PartialEquality(Int16);
+    instance Equality(Int16);
+    instance PartialEquality(Int32);
+    instance Equality(Int32);
+    instance PartialEquality(Int64);
+    instance Equality(Int64);
+    instance PartialEquality(Index);
+    instance Equality(Index);
 end module.

--- a/standard/src/Equality.aum
+++ b/standard/src/Equality.aum
@@ -18,4 +18,184 @@ module body Standard.Equality is
              return true;
         end;
     end;
+
+    instance PartialEquality(Bool) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Bool, R], b: &[Bool, S]): Bool is
+            let av: Bool := !a;
+            let bv: Bool := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Bool) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Bool, R], b: &[Bool, S]): Bool is
+            let av: Bool := !a;
+            let bv: Bool := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Nat8) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Nat8, R], b: &[Nat8, S]): Bool is
+            let av: Nat8 := !a;
+            let bv: Nat8 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Nat8) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Nat8, R], b: &[Nat8, S]): Bool is
+            let av: Nat8 := !a;
+            let bv: Nat8 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Nat16) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Nat16, R], b: &[Nat16, S]): Bool is
+            let av: Nat16 := !a;
+            let bv: Nat16 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Nat16) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Nat16, R], b: &[Nat16, S]): Bool is
+            let av: Nat16 := !a;
+            let bv: Nat16 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Nat32) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Nat32, R], b: &[Nat32, S]): Bool is
+            let av: Nat32 := !a;
+            let bv: Nat32 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Nat32) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Nat32, R], b: &[Nat32, S]): Bool is
+            let av: Nat32 := !a;
+            let bv: Nat32 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Nat64) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Nat64, R], b: &[Nat64, S]): Bool is
+            let av: Nat64 := !a;
+            let bv: Nat64 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Nat64) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Nat64, R], b: &[Nat64, S]): Bool is
+            let av: Nat64 := !a;
+            let bv: Nat64 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Int8) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Int8, R], b: &[Int8, S]): Bool is
+            let av: Int8 := !a;
+            let bv: Int8 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Int8) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Int8, R], b: &[Int8, S]): Bool is
+            let av: Int8 := !a;
+            let bv: Int8 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Int16) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Int16, R], b: &[Int16, S]): Bool is
+            let av: Int16 := !a;
+            let bv: Int16 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Int16) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Int16, R], b: &[Int16, S]): Bool is
+            let av: Int16 := !a;
+            let bv: Int16 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Int32) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Int32, R], b: &[Int32, S]): Bool is
+            let av: Int32 := !a;
+            let bv: Int32 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Int32) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Int32, R], b: &[Int32, S]): Bool is
+            let av: Int32 := !a;
+            let bv: Int32 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Int64) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Int64, R], b: &[Int64, S]): Bool is
+            let av: Int64 := !a;
+            let bv: Int64 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Int64) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Int64, R], b: &[Int64, S]): Bool is
+            let av: Int64 := !a;
+            let bv: Int64 := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance PartialEquality(Index) is
+        generic [R: Region, S: Region]
+		method partialEq(a: &[Index, R], b: &[Index, S]): Bool is
+            let av: Index := !a;
+            let bv: Index := !b;
+            return av = bv;
+        end;
+    end;
+
+    instance Equality(Index) is
+        generic [R: Region, S: Region]
+		method equal(a: &[Index, R], b: &[Index, S]): Bool is
+            let av: Index := !a;
+            let bv: Index := !b;
+            return av = bv;
+        end;
+    end;
 end module body.

--- a/standard/src/Order.aui
+++ b/standard/src/Order.aui
@@ -45,6 +45,36 @@ module Standard.Order is
     generic [T: Type(TotalOrder), R: Region, S: Region]
     function equal(a: &[T, R], b: &[T, S]): Bool;
 
+    generic [T: Type(TotalOrder), R: Region, S: Region]
+    function lessThan(a: &[T, R], b: &[T, S]): Bool;
+
+    generic [T: Type(TotalOrder), R: Region, S: Region]
+    function lessThanOrEqual(a: &[T, R], b: &[T, S]): Bool;
+
+    generic [T: Type(TotalOrder), R: Region, S: Region]
+    function greaterThan(a: &[T, R], b: &[T, S]): Bool;
+
+    generic [T: Type(TotalOrder), R: Region, S: Region]
+    function greaterThanOrEqual(a: &[T, R], b: &[T, S]): Bool;
+
+    instance PartialOrder(Bool);
+    instance TotalOrder(Bool);
     instance PartialOrder(Nat8);
     instance TotalOrder(Nat8);
+    instance PartialOrder(Nat16);
+    instance TotalOrder(Nat16);
+    instance PartialOrder(Nat32);
+    instance TotalOrder(Nat32);
+    instance PartialOrder(Nat64);
+    instance TotalOrder(Nat64);
+    instance PartialOrder(Int8);
+    instance TotalOrder(Int8);
+    instance PartialOrder(Int16);
+    instance TotalOrder(Int16);
+    instance PartialOrder(Int32);
+    instance TotalOrder(Int32);
+    instance PartialOrder(Int64);
+    instance TotalOrder(Int64);
+    instance PartialOrder(Index);
+    instance TotalOrder(Index);
 end module.

--- a/standard/src/Order.aum
+++ b/standard/src/Order.aum
@@ -17,6 +17,78 @@ module body Standard.Order is
         end case;
     end;
 
+    generic [T: Type(TotalOrder), R: Region, S: Region]
+    function lessThan(a: &[T, R], b: &[T, S]): Bool is
+        case compare(a, b) of
+             when LessThan do
+                  return true;
+             when Equal do
+                  return false;
+             when GreaterThan do
+                  return false;
+        end case;
+    end;
+
+    generic [T: Type(TotalOrder), R: Region, S: Region]
+    function lessThanOrEqual(a: &[T, R], b: &[T, S]): Bool is
+        case compare(a, b) of
+             when LessThan do
+                  return true;
+             when Equal do
+                  return true;
+             when GreaterThan do
+                  return false;
+        end case;
+    end;
+
+    generic [T: Type(TotalOrder), R: Region, S: Region]
+    function greaterThan(a: &[T, R], b: &[T, S]): Bool is
+        case compare(a, b) of
+             when LessThan do
+                  return false;
+             when Equal do
+                  return false;
+             when GreaterThan do
+                  return true;
+        end case;
+    end;
+
+    generic [T: Type(TotalOrder), R: Region, S: Region]
+    function greaterThanOrEqual(a: &[T, R], b: &[T, S]): Bool is
+        case compare(a, b) of
+             when LessThan do
+                  return false;
+             when Equal do
+                  return true;
+             when GreaterThan do
+                  return true;
+        end case;
+    end;
+
+    instance PartialOrder(Bool) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Bool, R], b: &[Bool, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Bool) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Bool, R], b: &[Bool, S]): Ordering is
+            let av: Bool := !a;
+            let bv: Bool := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
     instance PartialOrder(Nat8) is
         generic [R: Region, S: Region]
 		method partialCompare(a: &[Nat8, R], b: &[Nat8, S]): PartialOrdering is
@@ -29,6 +101,198 @@ module body Standard.Order is
 		method compare(a: &[Nat8, R], b: &[Nat8, S]): Ordering is
             let av: Nat8 := !a;
             let bv: Nat8 := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av > bv then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
+    instance PartialOrder(Nat16) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Nat16, R], b: &[Nat16, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Nat16) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Nat16, R], b: &[Nat16, S]): Ordering is
+            let av: Nat16 := !a;
+            let bv: Nat16 := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av > bv then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
+    instance PartialOrder(Nat32) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Nat32, R], b: &[Nat32, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Nat32) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Nat32, R], b: &[Nat32, S]): Ordering is
+            let av: Nat32 := !a;
+            let bv: Nat32 := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av > bv then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
+    instance PartialOrder(Nat64) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Nat64, R], b: &[Nat64, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Nat64) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Nat64, R], b: &[Nat64, S]): Ordering is
+            let av: Nat64 := !a;
+            let bv: Nat64 := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av > bv then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
+    instance PartialOrder(Int8) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Int8, R], b: &[Int8, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Int8) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Int8, R], b: &[Int8, S]): Ordering is
+            let av: Int8 := !a;
+            let bv: Int8 := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av > bv then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
+    instance PartialOrder(Int16) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Int16, R], b: &[Int16, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Int16) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Int16, R], b: &[Int16, S]): Ordering is
+            let av: Int16 := !a;
+            let bv: Int16 := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av > bv then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
+    instance PartialOrder(Int32) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Int32, R], b: &[Int32, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Int32) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Int32, R], b: &[Int32, S]): Ordering is
+            let av: Int32 := !a;
+            let bv: Int32 := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av > bv then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
+    instance PartialOrder(Int64) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Int64, R], b: &[Int64, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Int64) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Int64, R], b: &[Int64, S]): Ordering is
+            let av: Int64 := !a;
+            let bv: Int64 := !b;
+            if av = bv then
+                 return Equal();
+            else
+                if av > bv then
+                    return GreaterThan();
+                else
+                    return LessThan();
+                end if;
+            end if;
+        end;
+	end;
+
+    instance PartialOrder(Index) is
+        generic [R: Region, S: Region]
+		method partialCompare(a: &[Index, R], b: &[Index, S]): PartialOrdering is
+            return Comparable(order => compare(a, b));
+        end;
+	end;
+
+    instance TotalOrder(Index) is
+        generic [R: Region, S: Region]
+		method compare(a: &[Index, R], b: &[Index, S]): Ordering is
+            let av: Index := !a;
+            let bv: Index := !b;
             if av = bv then
                  return Equal();
             else

--- a/standard/test/Buffer.aum
+++ b/standard/test/Buffer.aum
@@ -82,7 +82,7 @@ module body Standard.Test.Buffer is
     function initializeTest(): Unit is
         testHeading("initialize, length, nth, and destroyFree");
         let b: Buffer[Int32] := initialize(3, 10);
-        assertLength(&b, 3);
+        assertTrue(length(&b) = 3, "length = 3");
         assertTrue(nth(&b, 0) = 10, "[0] = 10");
         assertTrue(nth(&b, 1) = 10, "[1] = 10");
         assertTrue(nth(&b, 2) = 10, "[2] = 10");
@@ -94,7 +94,7 @@ module body Standard.Test.Buffer is
     function initializeEmptyTest(): Unit is
         testHeading("initializeEmpty");
         let b: Buffer[Int32] := initialize(0, 10);
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         destroyFree(b);
         assertSuccess("destroyFree complete");
         return nil;
@@ -103,7 +103,7 @@ module body Standard.Test.Buffer is
     function storeTest(): Unit is
         testHeading("storeNth");
         var b: Buffer[Int32] := initialize(1, 10);
-        assertLength(&b, 1);
+        assertTrue(length(&b) = 1, "length = 1");
         assertTrue(nth(&b, 0) = 10, "[0] = 10");
         storeNth(&!b, 0, 20);
         assertTrue(nth(&b, 0) = 20, "[0] = 20");
@@ -115,7 +115,7 @@ module body Standard.Test.Buffer is
     function swapNthTest(): Unit is
         testHeading("swapNth");
         var b: Buffer[Int32] := initialize(1, 10);
-        assertLength(&b, 1);
+        assertTrue(length(&b) = 1, "length = 1");
         assertTrue(nth(&b, 0) = 10, "[0] = 10");
         let old: Int32 := swapNth(&!b, 0, 20);
         assertTrue(old = 10, "old = 10");
@@ -128,7 +128,7 @@ module body Standard.Test.Buffer is
     function swapIndexTest(): Unit is
         testHeading("swapIndex");
         var b: Buffer[Int32] := initialize(2, 0);
-        assertLength(&b, 2);
+        assertTrue(length(&b) = 2, "length = 2");
         storeNth(&!b, 0, 10);
         storeNth(&!b, 1, 20);
         assertTrue(nth(&b, 0) = 10, "[0] = 10");
@@ -148,7 +148,7 @@ module body Standard.Test.Buffer is
     function swapTransformTest(): Unit is
         testHeading("swapTransform");
         var b: Buffer[Int32] := initialize(1, 30);
-        assertLength(&b, 1);
+        assertTrue(length(&b) = 1, "length = 1");
         swapTransform(&!b, 0, double);
         assertTrue(nth(&b, 0) = 60, "[0] = 60");
         destroyFree(b);
@@ -160,7 +160,7 @@ module body Standard.Test.Buffer is
         testHeading("initialize then fill");
         var b: Buffer[Int32] := initialize(3, 10);
         fill(&!b, 20);
-        assertLength(&b, 3);
+        assertTrue(length(&b) = 3, "length = 3");
         assertTrue(nth(&b, 0) = 20, "[0] = 20");
         assertTrue(nth(&b, 1) = 20, "[1] = 20");
         assertTrue(nth(&b, 2) = 20, "[2] = 20");
@@ -173,22 +173,22 @@ module body Standard.Test.Buffer is
         testHeading("insertFront");
         var b: Buffer[Int32] := allocateEmpty();
         -- []
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         -- [3]
         insertFront(&!b, 3);
-        assertLength(&b, 1);
-        assertNth(&b, 0, 3);
+        assertTrue(length(&b) = 1, "length = 1");
+        assertTrue(nth(&b, 0) = 3, "[0] = 3");
         -- [2, 3]
         insertFront(&!b, 2);
-        assertLength(&b, 2);
-        assertNth(&b, 0, 2);
-        assertNth(&b, 1, 3);
+        assertTrue(length(&b) = 2, "length = 2");
+        assertTrue(nth(&b, 0) = 2, "[0] = 2");
+        assertTrue(nth(&b, 1) = 3, "[1] = 3");
         -- [1,2,3]
         insertFront(&!b, 1);
-        assertLength(&b, 3);
-        assertNth(&b, 0, 1);
-        assertNth(&b, 1, 2);
-        assertNth(&b, 2, 3);
+        assertTrue(length(&b) = 3, "length = 3");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
+        assertTrue(nth(&b, 2) = 3, "[2] = 3");
         destroyFree(b);
         return nil;
     end;
@@ -197,22 +197,22 @@ module body Standard.Test.Buffer is
         testHeading("insertBack");
         var b: Buffer[Int32] := allocateEmpty();
         -- []
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         -- [1]
         insertBack(&!b, 1);
-        assertLength(&b, 1);
-        assertNth(&b, 0, 1);
+        assertTrue(length(&b) = 1, "length = 1");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
         -- [1, 2]
         insertBack(&!b, 2);
-        assertLength(&b, 2);
-        assertNth(&b, 0, 1);
-        assertNth(&b, 1, 2);
+        assertTrue(length(&b) = 2, "length = 2");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
         -- [1,2,3]
         insertBack(&!b, 3);
-        assertLength(&b, 3);
-        assertNth(&b, 0, 1);
-        assertNth(&b, 1, 2);
-        assertNth(&b, 2, 3);
+        assertTrue(length(&b) = 3, "length = 3");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
+        assertTrue(nth(&b, 2) = 3, "[2] = 3");
         destroyFree(b);
         return nil;
     end;
@@ -221,27 +221,27 @@ module body Standard.Test.Buffer is
         testHeading("removeFirst");
         var b: Buffer[Int32] := allocateEmpty();
         -- []
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         insertBack(&!b, 1);
         insertBack(&!b, 2);
         insertBack(&!b, 3);
         -- [1,2,3]
-        assertLength(&b, 3);
-        assertNth(&b, 0, 1);
-        assertNth(&b, 1, 2);
-        assertNth(&b, 2, 3);
+        assertTrue(length(&b) = 3, "length = 3");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
+        assertTrue(nth(&b, 2) = 3, "[2] = 3");
         -- [2,3]
         removeFirst(&!b);
-        assertLength(&b, 2);
-        assertNth(&b, 0, 2);
-        assertNth(&b, 1, 3);
+        assertTrue(length(&b) = 2, "length = 2");
+        assertTrue(nth(&b, 0) = 2, "[0] = 2");
+        assertTrue(nth(&b, 1) = 3, "[1] = 3");
         -- [3]
         removeFirst(&!b);
-        assertLength(&b, 1);
-        assertNth(&b, 0, 3);
+        assertTrue(length(&b) = 1, "length = 1");
+        assertTrue(nth(&b, 0) = 3, "[0] = 3");
         -- []
         removeFirst(&!b);
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         destroyEmpty(b);
         return nil;
     end;
@@ -250,27 +250,27 @@ module body Standard.Test.Buffer is
         testHeading("removeLast");
         var b: Buffer[Int32] := allocateEmpty();
         -- []
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         insertBack(&!b, 1);
         insertBack(&!b, 2);
         insertBack(&!b, 3);
         -- [1,2,3]
-        assertLength(&b, 3);
-        assertNth(&b, 0, 1);
-        assertNth(&b, 1, 2);
-        assertNth(&b, 2, 3);
+        assertTrue(length(&b) = 3, "length = 3");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
+        assertTrue(nth(&b, 2) = 3, "[2] = 3");
         -- [1,2]
         removeLast(&!b);
-        assertLength(&b, 2);
-        assertNth(&b, 0, 1);
-        assertNth(&b, 1, 2);
+        assertTrue(length(&b) = 2, "length = 2");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
         -- [1]
         removeLast(&!b);
-        assertLength(&b, 1);
-        assertNth(&b, 0, 1);
+        assertTrue(length(&b) = 1, "length = 1");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
         -- []
         removeLast(&!b);
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         destroyEmpty(b);
         return nil;
     end;
@@ -279,9 +279,9 @@ module body Standard.Test.Buffer is
         testHeading("reverse (empty)");
         -- Test empty array
         var b: Buffer[Int32] := allocateEmpty();
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         reverse(&!b);
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         destroyFree(b);
         return nil;
     end;
@@ -294,16 +294,16 @@ module body Standard.Test.Buffer is
         insertBack(&!b, 2);
         insertBack(&!b, 3);
         -- [1,2,3]
-        assertLength(&b, 3);
-        assertNth(&b, 0, 1);
-        assertNth(&b, 1, 2);
-        assertNth(&b, 2, 3);
+        assertTrue(length(&b) = 3, "length = 3");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
+        assertTrue(nth(&b, 2) = 3, "[2] = 3");
         reverse(&!b);
         -- [3,2,1]
-        assertLength(&b, 3);
-        assertNth(&b, 0, 3);
-        assertNth(&b, 1, 2);
-        assertNth(&b, 2, 1);
+        assertTrue(length(&b) = 3, "length = 3");
+        assertTrue(nth(&b, 0) = 3, "[0] = 3");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
+        assertTrue(nth(&b, 2) = 1, "[2] = 1");
         destroyFree(b);
         return nil;
     end;
@@ -336,7 +336,7 @@ module body Standard.Test.Buffer is
 
         var b: Buffer[Int32] := allocateEmpty();
         inPlaceMap(&!b, double);
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
  
         destroyFree(b);
         assertSuccess("destroyFree complete");
@@ -390,7 +390,7 @@ module body Standard.Test.Buffer is
         let b1: Buffer[CardinalDirection] := allocateEmpty();
         let b2: Buffer[Nat8] := map(b1, directionToChar);
         
-        assertLength(&b2, 0);
+        assertTrue(length(&b2) = 0, "length = 0");
         
         destroyFree(b2);
         assertSuccess("destroyFree complete");
@@ -402,12 +402,12 @@ module body Standard.Test.Buffer is
 
         var b: Buffer[Int32] := allocateEmpty();
         -- []
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         insertBack(&!b, 1);
         insertBack(&!b, 2);
         insertBack(&!b, 3);
         -- [1,2,3]
-        assertLength(&b, 3);
+        assertTrue(length(&b) = 3, "length = 3");
 
         -- Get an immutable span.
         borrow ref: &[Buffer[Int32], R] := &b do
@@ -429,12 +429,12 @@ module body Standard.Test.Buffer is
 
         var b: Buffer[Int32] := allocateEmpty();
         -- []
-        assertLength(&b, 0);
+        assertTrue(length(&b) = 0, "length = 0");
         insertBack(&!b, 1);
         insertBack(&!b, 2);
         insertBack(&!b, 3);
         -- [1,2,3]
-        assertLength(&b, 3);
+        assertTrue(length(&b) = 3, "length = 3");
 
         -- Get a mutable span.
         borrow ref: &![Buffer[Int32], R] := &!b do
@@ -468,18 +468,18 @@ module body Standard.Test.Buffer is
         insertBack(&!b, 3);
         insertBack(&!b, 4);
         -- [1,2,3,4]
-        assertLength(&b, 4);
-        assertNth(&b, 0, 1);
-        assertNth(&b, 1, 2);
-        assertNth(&b, 2, 3);
-        assertNth(&b, 3, 4);
+        assertTrue(length(&b) = 4, "length = 4");
+        assertTrue(nth(&b, 0) = 1, "[0] = 1");
+        assertTrue(nth(&b, 1) = 2, "[1] = 2");
+        assertTrue(nth(&b, 2) = 3, "[2] = 3");
+        assertTrue(nth(&b, 3) = 4, "[3] = 4");
         reverse(&!b);
         -- [4,3,2,1]
-        assertLength(&b, 4);
-        assertNth(&b, 0, 4);
-        assertNth(&b, 1, 3);
-        assertNth(&b, 2, 2);
-        assertNth(&b, 3, 1);
+        assertTrue(length(&b) = 4, "length = 4");
+        assertTrue(nth(&b, 0) = 4, "[0] = 4");
+        assertTrue(nth(&b, 1) = 3, "[1] = 3");
+        assertTrue(nth(&b, 2) = 2, "[2] = 2");
+        assertTrue(nth(&b, 3) = 1, "[3] = 1");
         destroyFree(b);
         return nil;
     end;
@@ -493,15 +493,15 @@ module body Standard.Test.Buffer is
         insertBack(&!b, 4);
         insertBack(&!b, 5);
         -- [1,2,3,4,5]
-        assertLength(&b, 5);
+        assertTrue(length(&b) = 5, "length = 5");
         reverse(&!b);
         -- [5,4,3,2,1]
-        assertLength(&b, 5);
-        assertNth(&b, 0, 5);
-        assertNth(&b, 1, 4);
-        assertNth(&b, 2, 3);  -- Middle element
-        assertNth(&b, 3, 2);
-        assertNth(&b, 4, 1);
+        assertTrue(length(&b) = 5, "length = 5");
+        assertTrue(nth(&b, 0) = 5, "[0] = 5");
+        assertTrue(nth(&b, 1) = 4, "[1] = 4");
+        assertTrue(nth(&b, 2) = 3, "[2] = 3");  -- Middle element
+        assertTrue(nth(&b, 3) = 2, "[3] = 2");
+        assertTrue(nth(&b, 4) = 1, "[4] = 1");
         destroyFree(b);
         return nil;
     end;
@@ -515,17 +515,17 @@ module body Standard.Test.Buffer is
             insertBack(&!b, indexToInt32(i));
         end for;
         
-        assertLength(&b, 15);
+        assertTrue(length(&b) = 15, "length = 15");
         
         -- Trigger resize
         insertBack(&!b, 15);
-        assertLength(&b, 16);
-        assertNth(&b, 15, 15);
+        assertTrue(length(&b) = 16, "length = 16");
+        assertTrue(nth(&b, 15) = 15, "[15] = 15");
         
         -- Trigger another resize
         insertBack(&!b, 16);
-        assertLength(&b, 17);
-        assertNth(&b, 16, 16);
+        assertTrue(length(&b) = 17, "length = 17");
+        assertTrue(nth(&b, 16) = 16, "[16] = 16");
         
         destroyFree(b);
         return nil;
@@ -540,12 +540,23 @@ module body Standard.Test.Buffer is
             insertBack(&!b, indexToInt32(i));
         end for;
         
-        assertLength(&b, 101);
+        assertTrue(length(&b) = 101, "length = 101");
         
-        -- Verify all elements preserved
+        -- Verify all elements preserved. Only print per-element values on failure.
         for i from 0 to 100 do
-            assertTrue(nth(&b, i) = indexToInt32(i), "Element at index preserved after resizes");
+            let expected: Int32 := indexToInt32(i);
+            let actual: Int32 := nth(&b, i);
+            if actual /= expected then
+                print("        Failure: capacity growth mismatch at index ");
+                print(i);
+                print(": expected ");
+                print(expected);
+                print(", actual ");
+                printLn(actual);
+                assertTrue(false, "capacity growth preserves every inserted element after repeated resizes");
+            end if;
         end for;
+        assertSuccess("ALL capacity growth preserves every inserted element after repeated resizes");
         
         destroyFree(b);
         return nil;
@@ -556,17 +567,17 @@ module body Standard.Test.Buffer is
         
         -- Empty buffer
         let b1: Buffer[Int32] := allocateEmpty();
-        assertLength(&b1, 0);
+        assertTrue(length(&b1) = 0, "length = 0");
         destroyEmpty(b1);
         
         -- Single element buffer
         var b2: Buffer[Int32] := initialize(1, 42);
-        assertLength(&b2, 1);
-        assertNth(&b2, 0, 42);
+        assertTrue(length(&b2) = 1, "length = 1");
+        assertTrue(nth(&b2, 0) = 42, "[0] = 42");
         
         insertBack(&!b2, 43);
-        assertLength(&b2, 2);
-        assertNth(&b2, 1, 43);
+        assertTrue(length(&b2) = 2, "length = 2");
+        assertTrue(nth(&b2, 1) = 43, "[1] = 43");
         
         destroyFree(b2);
         
@@ -576,11 +587,22 @@ module body Standard.Test.Buffer is
             insertBack(&!b3, indexToInt32(i * 10));
         end for;
         
-        assertLength(&b3, 16);
+        assertTrue(length(&b3) = 16, "length = 16");
         
         for i from 0 to 15 do
-            assertTrue(nth(&b3, i) = indexToInt32(i * 10), "Minimum capacity boundary test");
+            let expected: Int32 := indexToInt32(i * 10);
+            let actual: Int32 := nth(&b3, i);
+            if actual /= expected then
+                print("        Failure: minimum-capacity boundary mismatch at index ");
+                print(i);
+                print(": expected ");
+                print(expected);
+                print(", actual ");
+                printLn(actual);
+                assertTrue(false, "minimum-capacity boundary preserves inserted element values");
+            end if;
         end for;
+        assertSuccess("ALL minimum-capacity boundary preserves inserted element values");
         
         destroyFree(b3);
         
@@ -592,17 +614,6 @@ module body Standard.Test.Buffer is
     --- Utilities
     ---
 
-    generic [T: Type, R: Region]
-    function assertLength(ref: &[Buffer[T], R], len: Index): Unit is
-        assertTrue(length(ref) = len, "length");
-        return nil;
-    end;
-
-    generic [T: Free, R: Region]
-    function assertNth(ref: &[Buffer[T], R], pos: Index, value: T): Unit is
-        assertTrue(nth(ref, pos) = value, "nth");
-        return nil;
-    end;
 
     -- Helper function to convert Index to Int32 for tests
     function indexToInt32(idx: Index): Int32 is

--- a/standard/test/Equality.aum
+++ b/standard/test/Equality.aum
@@ -19,14 +19,174 @@ module body Standard.Test.Equality is
     function equalityTestSuite(): Unit is
         suiteHeading("Standard.Equality");
         unitTest();
+        boolTest();
+        nat8Test();
+        nat16Test();
+        nat32Test();
+        nat64Test();
+        int8Test();
+        int16Test();
+        int32Test();
+        int64Test();
+        indexTest();
         return nil;
     end;
 
     function unitTest(): Unit is
         testHeading("Unit");
         let u: Unit := nil;
-        assertTrue(partialEq(&u, &u), "nil is partially equivalent to itself.");
-        assertTrue(equal(&u, &u), "nil is equal to itself.");
+        assertTrue(partialEq(&u, &u), "Unit partialEq() returns true for nil.");
+        assertTrue(equal(&u, &u), "Unit equal() returns true for nil.");
+        return nil;
+    end;
+
+    function boolTest(): Unit is
+        testHeading("Bool");
+        let a: Bool := false;
+        let b: Bool := true;
+        assertTrue(partialEq(&a, &a), "Bool partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Bool partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Bool partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Bool partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Bool equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Bool equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Bool equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Bool equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function nat8Test(): Unit is
+        testHeading("Nat8");
+        let a: Nat8 := 1;
+        let b: Nat8 := 2;
+        assertTrue(partialEq(&a, &a), "Nat8 partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Nat8 partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Nat8 partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Nat8 partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Nat8 equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Nat8 equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Nat8 equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Nat8 equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function nat16Test(): Unit is
+        testHeading("Nat16");
+        let a: Nat16 := 1;
+        let b: Nat16 := 2;
+        assertTrue(partialEq(&a, &a), "Nat16 partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Nat16 partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Nat16 partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Nat16 partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Nat16 equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Nat16 equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Nat16 equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Nat16 equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function nat32Test(): Unit is
+        testHeading("Nat32");
+        let a: Nat32 := 1;
+        let b: Nat32 := 2;
+        assertTrue(partialEq(&a, &a), "Nat32 partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Nat32 partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Nat32 partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Nat32 partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Nat32 equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Nat32 equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Nat32 equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Nat32 equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function nat64Test(): Unit is
+        testHeading("Nat64");
+        let a: Nat64 := 1;
+        let b: Nat64 := 2;
+        assertTrue(partialEq(&a, &a), "Nat64 partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Nat64 partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Nat64 partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Nat64 partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Nat64 equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Nat64 equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Nat64 equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Nat64 equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function int8Test(): Unit is
+        testHeading("Int8");
+        let a: Int8 := 1;
+        let b: Int8 := 2;
+        assertTrue(partialEq(&a, &a), "Int8 partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Int8 partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Int8 partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Int8 partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Int8 equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Int8 equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Int8 equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Int8 equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function int16Test(): Unit is
+        testHeading("Int16");
+        let a: Int16 := 1;
+        let b: Int16 := 2;
+        assertTrue(partialEq(&a, &a), "Int16 partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Int16 partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Int16 partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Int16 partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Int16 equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Int16 equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Int16 equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Int16 equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function int32Test(): Unit is
+        testHeading("Int32");
+        let a: Int32 := 1;
+        let b: Int32 := 2;
+        assertTrue(partialEq(&a, &a), "Int32 partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Int32 partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Int32 partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Int32 partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Int32 equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Int32 equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Int32 equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Int32 equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function int64Test(): Unit is
+        testHeading("Int64");
+        let a: Int64 := 1;
+        let b: Int64 := 2;
+        assertTrue(partialEq(&a, &a), "Int64 partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Int64 partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Int64 partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Int64 partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Int64 equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Int64 equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Int64 equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Int64 equal() is false for distinct values in reverse order.");
+        return nil;
+    end;
+
+    function indexTest(): Unit is
+        testHeading("Index");
+        let a: Index := 1;
+        let b: Index := 2;
+        assertTrue(partialEq(&a, &a), "Index partialEq() returns true for the first value.");
+        assertTrue(partialEq(&b, &b), "Index partialEq() returns true for the second value.");
+        assertFalse(partialEq(&a, &b), "Index partialEq() returns false for distinct values.");
+        assertFalse(partialEq(&b, &a), "Index partialEq() is false for distinct values in reverse order.");
+        assertTrue(equal(&a, &a), "Index equal() returns true for the first value.");
+        assertTrue(equal(&b, &b), "Index equal() returns true for the second value.");
+        assertFalse(equal(&a, &b), "Index equal() returns false for distinct values.");
+        assertFalse(equal(&b, &a), "Index equal() is false for distinct values in reverse order.");
         return nil;
     end;
 end module body.

--- a/standard/test/Order.aum
+++ b/standard/test/Order.aum
@@ -5,7 +5,11 @@
 -- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 --
 import Standard.Order (
-    equal
+    equal,
+    lessThan,
+    lessThanOrEqual,
+    greaterThan,
+    greaterThanOrEqual
 );
 import Standard.Test.Unit (
     suiteHeading,
@@ -17,14 +21,246 @@ import Standard.Test.Unit (
 module body Standard.Test.Order is
     function orderTestSuite(): Unit is
         suiteHeading("Standard.Order");
+        boolTest();
         nat8Test();
+        nat16Test();
+        nat32Test();
+        nat64Test();
+        int8Test();
+        int16Test();
+        int32Test();
+        int64Test();
+        indexTest();
+        return nil;
+    end;
+
+    function boolTest(): Unit is
+        testHeading("Bool");
+        let a: Bool := false;
+        let b: Bool := true;
+        assertTrue(equal(&a, &a), "Bool equal() returns true for false.");
+        assertTrue(equal(&b, &b), "Bool equal() returns true for true.");
+        assertFalse(equal(&a, &b), "Bool equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Bool equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Bool lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Bool lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Bool lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Bool lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Bool lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Bool lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Bool greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Bool greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Bool greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Bool greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Bool greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Bool greaterThanOrEqual() returns false for increasing argument order.");
         return nil;
     end;
 
     function nat8Test(): Unit is
         testHeading("Nat8");
-        let a: Nat8 := 0;
-        assertTrue(equal(&a, &a), "equal() works");
+        let a: Nat8 := 1;
+        let b: Nat8 := 2;
+        assertTrue(equal(&a, &a), "Nat8 equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Nat8 equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Nat8 equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Nat8 equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Nat8 lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Nat8 lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Nat8 lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Nat8 lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Nat8 lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Nat8 lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Nat8 greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Nat8 greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Nat8 greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Nat8 greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Nat8 greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Nat8 greaterThanOrEqual() returns false for increasing argument order.");
+        return nil;
+    end;
+
+    function nat16Test(): Unit is
+        testHeading("Nat16");
+        let a: Nat16 := 1;
+        let b: Nat16 := 2;
+        assertTrue(equal(&a, &a), "Nat16 equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Nat16 equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Nat16 equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Nat16 equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Nat16 lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Nat16 lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Nat16 lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Nat16 lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Nat16 lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Nat16 lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Nat16 greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Nat16 greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Nat16 greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Nat16 greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Nat16 greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Nat16 greaterThanOrEqual() returns false for increasing argument order.");
+        return nil;
+    end;
+
+    function nat32Test(): Unit is
+        testHeading("Nat32");
+        let a: Nat32 := 1;
+        let b: Nat32 := 2;
+        assertTrue(equal(&a, &a), "Nat32 equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Nat32 equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Nat32 equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Nat32 equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Nat32 lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Nat32 lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Nat32 lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Nat32 lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Nat32 lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Nat32 lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Nat32 greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Nat32 greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Nat32 greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Nat32 greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Nat32 greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Nat32 greaterThanOrEqual() returns false for increasing argument order.");
+        return nil;
+    end;
+
+    function nat64Test(): Unit is
+        testHeading("Nat64");
+        let a: Nat64 := 1;
+        let b: Nat64 := 2;
+        assertTrue(equal(&a, &a), "Nat64 equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Nat64 equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Nat64 equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Nat64 equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Nat64 lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Nat64 lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Nat64 lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Nat64 lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Nat64 lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Nat64 lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Nat64 greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Nat64 greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Nat64 greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Nat64 greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Nat64 greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Nat64 greaterThanOrEqual() returns false for increasing argument order.");
+        return nil;
+    end;
+
+    function int8Test(): Unit is
+        testHeading("Int8");
+        let a: Int8 := 1;
+        let b: Int8 := 2;
+        assertTrue(equal(&a, &a), "Int8 equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Int8 equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Int8 equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Int8 equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Int8 lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Int8 lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Int8 lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Int8 lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Int8 lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Int8 lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Int8 greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Int8 greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Int8 greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Int8 greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Int8 greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Int8 greaterThanOrEqual() returns false for increasing argument order.");
+        return nil;
+    end;
+
+    function int16Test(): Unit is
+        testHeading("Int16");
+        let a: Int16 := 1;
+        let b: Int16 := 2;
+        assertTrue(equal(&a, &a), "Int16 equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Int16 equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Int16 equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Int16 equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Int16 lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Int16 lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Int16 lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Int16 lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Int16 lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Int16 lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Int16 greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Int16 greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Int16 greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Int16 greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Int16 greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Int16 greaterThanOrEqual() returns false for increasing argument order.");
+        return nil;
+    end;
+
+    function int32Test(): Unit is
+        testHeading("Int32");
+        let a: Int32 := 1;
+        let b: Int32 := 2;
+        assertTrue(equal(&a, &a), "Int32 equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Int32 equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Int32 equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Int32 equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Int32 lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Int32 lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Int32 lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Int32 lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Int32 lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Int32 lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Int32 greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Int32 greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Int32 greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Int32 greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Int32 greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Int32 greaterThanOrEqual() returns false for increasing argument order.");
+        return nil;
+    end;
+
+    function int64Test(): Unit is
+        testHeading("Int64");
+        let a: Int64 := 1;
+        let b: Int64 := 2;
+        assertTrue(equal(&a, &a), "Int64 equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Int64 equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Int64 equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Int64 equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Int64 lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Int64 lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Int64 lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Int64 lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Int64 lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Int64 lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Int64 greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Int64 greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Int64 greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Int64 greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Int64 greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Int64 greaterThanOrEqual() returns false for increasing argument order.");
+        return nil;
+    end;
+
+    function indexTest(): Unit is
+        testHeading("Index");
+        let a: Index := 1;
+        let b: Index := 2;
+        assertTrue(equal(&a, &a), "Index equal() returns true for a.");
+        assertTrue(equal(&b, &b), "Index equal() returns true for b.");
+        assertFalse(equal(&a, &b), "Index equal() returns false for ordered distinct values.");
+        assertFalse(equal(&b, &a), "Index equal() returns false for reverse distinct values.");
+        assertTrue(lessThan(&a, &b), "Index lessThan() returns true for increasing values.");
+        assertFalse(lessThan(&b, &a), "Index lessThan() returns false for decreasing values.");
+        assertFalse(lessThan(&a, &a), "Index lessThan() returns false for equal values.");
+        assertTrue(lessThanOrEqual(&a, &b), "Index lessThanOrEqual() returns true for increasing values.");
+        assertTrue(lessThanOrEqual(&a, &a), "Index lessThanOrEqual() returns true for equal values.");
+        assertFalse(lessThanOrEqual(&b, &a), "Index lessThanOrEqual() returns false for decreasing values.");
+        assertTrue(greaterThan(&b, &a), "Index greaterThan() returns true for decreasing argument order.");
+        assertFalse(greaterThan(&a, &b), "Index greaterThan() returns false for increasing argument order.");
+        assertFalse(greaterThan(&a, &a), "Index greaterThan() returns false for equal values.");
+        assertTrue(greaterThanOrEqual(&b, &a), "Index greaterThanOrEqual() returns true for decreasing argument order.");
+        assertTrue(greaterThanOrEqual(&b, &b), "Index greaterThanOrEqual() returns true for equal values.");
+        assertFalse(greaterThanOrEqual(&a, &b), "Index greaterThanOrEqual() returns false for increasing argument order.");
         return nil;
     end;
 end module body.


### PR DESCRIPTION
* feat: add Equality/Order instances for Bool, Nat, Int, and Index

* fix: rely on resizeArray for Buffer resizing to preserve data

* test: expand primitive coverage and improve Buffer diagnostics

* build: add explicit build/test targets to standard/Makefile